### PR TITLE
🤖 Add authors and contributors to Practice Exercises

### DIFF
--- a/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -1,22 +1,11 @@
 {
   "blurb": "Help Annalyn free her best friend using boolean logic in JavaScript",
-  "authors": [
-    "ovidiu141"
-  ],
-  "contributors": [
-    "rishiosaur",
-    "SleeplessByte"
-  ],
+  "authors": ["ovidiu141"],
+  "contributors": ["rishiosaur", "SleeplessByte"],
   "files": {
-    "solution": [
-      "annalyns-infiltration.js"
-    ],
-    "test": [
-      "annalyns-infiltration.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["annalyns-infiltration.js"],
+    "test": ["annalyns-infiltration.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/annalyns-infiltration/package.json
+++ b/exercises/concept/annalyns-infiltration/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/array-loops/.meta/config.json
+++ b/exercises/concept/array-loops/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "TODO: add blurb for array-loops exercise",
-  "authors": [
-    "rishiosaur"
-  ],
-  "contributors": [
-    "SleeplessByte"
-  ],
+  "authors": ["rishiosaur"],
+  "contributors": ["SleeplessByte"],
   "files": {
-    "solution": [
-      "array-loops.js"
-    ],
-    "test": [
-      "array-loops.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["array-loops.js"],
+    "test": ["array-loops.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/array-loops/package.json
+++ b/exercises/concept/array-loops/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/closures/.meta/config.json
+++ b/exercises/concept/closures/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "TODO: add blurb for closures exercise",
-  "authors": [
-    "neenjaw"
-  ],
-  "contributors": [
-    "SleeplessByte"
-  ],
+  "authors": ["neenjaw"],
+  "contributors": ["SleeplessByte"],
   "files": {
-    "solution": [
-      "closures.js"
-    ],
-    "test": [
-      "closures.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["closures.js"],
+    "test": ["closures.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/closures/package.json
+++ b/exercises/concept/closures/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/elyses-analytic-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-analytic-enchantments/.meta/config.json
@@ -1,20 +1,11 @@
 {
   "blurb": "TODO: add blurb for elyses-analytic-enchantments exercise",
-  "authors": [
-    "peterchu999",
-    "SleeplessByte"
-  ],
+  "authors": ["peterchu999", "SleeplessByte"],
   "contributors": [],
   "files": {
-    "solution": [
-      "enchantments.js"
-    ],
-    "test": [
-      "enchantments.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["enchantments.js"],
+    "test": ["enchantments.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/elyses-analytic-enchantments/package.json
+++ b/exercises/concept/elyses-analytic-enchantments/package.json
@@ -12,7 +12,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/elyses-destructured-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-destructured-enchantments/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "TODO: add blurb for elyses-destructured-enchantments exercise",
-  "authors": [
-    "kristinaborn"
-  ],
-  "contributors": [
-    "SleeplessByte"
-  ],
+  "authors": ["kristinaborn"],
+  "contributors": ["SleeplessByte"],
   "files": {
-    "solution": [
-      "enchantments.js"
-    ],
-    "test": [
-      "enchantments.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["enchantments.js"],
+    "test": ["enchantments.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/elyses-destructured-enchantments/package.json
+++ b/exercises/concept/elyses-destructured-enchantments/package.json
@@ -12,7 +12,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/elyses-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-enchantments/.meta/config.json
@@ -1,24 +1,11 @@
 {
   "blurb": "TODO: add blurb for elyses-enchantments exercise",
-  "authors": [
-    "ovidiu141"
-  ],
-  "contributors": [
-    "peterchu999",
-    "SleeplessByte"
-  ],
+  "authors": ["ovidiu141"],
+  "contributors": ["peterchu999", "SleeplessByte"],
   "files": {
-    "solution": [
-      "enchantments.js"
-    ],
-    "test": [
-      "enchantments.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["enchantments.js"],
+    "test": ["enchantments.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": [
-    "go/basic-slices"
-  ]
+  "forked_from": ["go/basic-slices"]
 }

--- a/exercises/concept/elyses-enchantments/package.json
+++ b/exercises/concept/elyses-enchantments/package.json
@@ -12,7 +12,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/elyses-transformative-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-transformative-enchantments/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "TODO: add blurb for elyses-transformative-enchantments exercise",
-  "authors": [
-    "yyyc514"
-  ],
-  "contributors": [
-    "SleeplessByte"
-  ],
+  "authors": ["yyyc514"],
+  "contributors": ["SleeplessByte"],
   "files": {
-    "solution": [
-      "enchantments.js"
-    ],
-    "test": [
-      "enchantments.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["enchantments.js"],
+    "test": ["enchantments.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/elyses-transformative-enchantments/package.json
+++ b/exercises/concept/elyses-transformative-enchantments/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/freelancer-rates/.meta/config.json
+++ b/exercises/concept/freelancer-rates/.meta/config.json
@@ -1,19 +1,11 @@
 {
   "blurb": "Learn about numbers whilst helping a freelancer communicate with a project manager about day- and month rates.",
-  "authors": [
-    "SleeplessByte"
-  ],
+  "authors": ["SleeplessByte"],
   "contributors": [],
   "files": {
-    "solution": [
-      "freelancer-rates.js"
-    ],
-    "test": [
-      "freelancer-rates.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["freelancer-rates.js"],
+    "test": ["freelancer-rates.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/freelancer-rates/package.json
+++ b/exercises/concept/freelancer-rates/package.json
@@ -12,7 +12,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/fruit-picker/.meta/config.json
+++ b/exercises/concept/fruit-picker/.meta/config.json
@@ -1,21 +1,10 @@
 {
   "blurb": "TODO: add blurb for fruit-picker exercise",
-  "authors": [
-    "neenjaw"
-  ],
-  "contributors": [
-    "SleeplessByte"
-  ],
+  "authors": ["neenjaw"],
+  "contributors": ["SleeplessByte"],
   "files": {
-    "solution": [
-      "fruit-picker.js",
-      "grocer.js"
-    ],
-    "test": [
-      "fruit-picker.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["fruit-picker.js", "grocer.js"],
+    "test": ["fruit-picker.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   }
 }

--- a/exercises/concept/fruit-picker/package.json
+++ b/exercises/concept/fruit-picker/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/lasagna/.meta/config.json
+++ b/exercises/concept/lasagna/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "Learn the basics of JavaScript cooking a brilliant lasagna from your favorite cooking book",
-  "authors": [
-    "SleeplessByte"
-  ],
+  "authors": ["SleeplessByte"],
   "contributors": [],
   "files": {
-    "solution": [
-      "lasagna.js"
-    ],
-    "test": [
-      "lasagna.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["lasagna.js"],
+    "test": ["lasagna.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": [
-    "ruby/lasagna"
-  ]
+  "forked_from": ["ruby/lasagna"]
 }

--- a/exercises/concept/lasagna/package.json
+++ b/exercises/concept/lasagna/package.json
@@ -12,7 +12,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/lucky-numbers/.meta/config.json
+++ b/exercises/concept/lucky-numbers/.meta/config.json
@@ -1,22 +1,11 @@
 {
   "blurb": "TODO: add blurb for lucky-numbers exercise",
-  "authors": [
-    "shubhsk88"
-  ],
-  "contributors": [
-    "neenjaw",
-    "SleeplessByte"
-  ],
+  "authors": ["shubhsk88"],
+  "contributors": ["neenjaw", "SleeplessByte"],
   "files": {
-    "solution": [
-      "lucky-numbers.js"
-    ],
-    "test": [
-      "lucky-numbers.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["lucky-numbers.js"],
+    "test": ["lucky-numbers.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/lucky-numbers/package.json
+++ b/exercises/concept/lucky-numbers/package.json
@@ -12,7 +12,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/nullability/.meta/config.json
+++ b/exercises/concept/nullability/.meta/config.json
@@ -1,22 +1,11 @@
 {
   "blurb": "TODO: add blurb for nullability exercise",
-  "authors": [
-    "SleeplessByte",
-    "Jlamon"
-  ],
+  "authors": ["SleeplessByte", "Jlamon"],
   "contributors": [],
   "files": {
-    "solution": [
-      "nullability.js"
-    ],
-    "test": [
-      "nullability.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["nullability.js"],
+    "test": ["nullability.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": [
-    "csharp/nullability"
-  ]
+  "forked_from": ["csharp/nullability"]
 }

--- a/exercises/concept/nullability/package.json
+++ b/exercises/concept/nullability/package.json
@@ -12,7 +12,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/promises/.meta/config.json
+++ b/exercises/concept/promises/.meta/config.json
@@ -1,19 +1,11 @@
 {
   "blurb": "TODO: add blurb for promises exercise",
-  "authors": [
-    "SleeplessByte"
-  ],
+  "authors": ["SleeplessByte"],
   "contributors": [],
   "files": {
-    "solution": [
-      "promises.js"
-    ],
-    "test": [
-      "promises.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["promises.js"],
+    "test": ["promises.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/promises/package.json
+++ b/exercises/concept/promises/package.json
@@ -12,7 +12,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/recursion/.meta/config.json
+++ b/exercises/concept/recursion/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "TODO: add blurb for recursion exercise",
-  "authors": [
-    "SleeplessByte"
-  ],
+  "authors": ["SleeplessByte"],
   "contributors": [],
   "files": {
-    "solution": [
-      "recursion.js"
-    ],
-    "test": [
-      "recursion.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["recursion.js"],
+    "test": ["recursion.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": [
-    "csharp/nullability"
-  ]
+  "forked_from": ["csharp/nullability"]
 }

--- a/exercises/concept/recursion/package.json
+++ b/exercises/concept/recursion/package.json
@@ -12,7 +12,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/strings/.meta/config.json
+++ b/exercises/concept/strings/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "TODO: add blurb for strings exercise",
-  "authors": [
-    "SleeplessByte"
-  ],
-  "contributors": [
-    "hayashi-ay"
-  ],
+  "authors": ["SleeplessByte"],
+  "contributors": ["hayashi-ay"],
   "files": {
-    "solution": [
-      "strings.js"
-    ],
-    "test": [
-      "strings.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["strings.js"],
+    "test": ["strings.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/strings/package.json
+++ b/exercises/concept/strings/package.json
@@ -12,7 +12,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/concept/vehicle-purchase/.meta/config.json
+++ b/exercises/concept/vehicle-purchase/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "Learn about comparison and conditionals while preparing for your next vehicle purchase",
-  "authors": [
-    "junedev"
-  ],
+  "authors": ["junedev"],
   "contributors": [],
   "files": {
-    "solution": [
-      "vehicle-purchase.js"
-    ],
-    "test": [
-      "vehicle-purchase.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["vehicle-purchase.js"],
+    "test": ["vehicle-purchase.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": [
-    "julia/vehicle-purchase"
-  ]
+  "forked_from": ["julia/vehicle-purchase"]
 }

--- a/exercises/concept/vehicle-purchase/package.json
+++ b/exercises/concept/vehicle-purchase/package.json
@@ -12,7 +12,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -20,15 +18,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "accumulate.js"
-    ],
-    "test": [
-      "accumulate.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["accumulate.js"],
+    "test": ["accumulate.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["accumulate.js"],
-    "test": ["accumulate.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "accumulate.js"
+    ],
+    "test": [
+      "accumulate.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,26 +1,26 @@
 {
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
     "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["accumulate.js"],
-    "test": ["accumulate.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "accumulate.js"
+    ],
+    "test": [
+      "accumulate.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "gargrave",
@@ -12,15 +10,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "accumulate.js"
-    ],
-    "test": [
-      "accumulate.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["accumulate.js"],
+    "test": ["accumulate.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/accumulate/package.json
+++ b/exercises/practice/accumulate/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a long phrase to its acronym",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -13,15 +11,9 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "acronym.js"
-    ],
-    "test": [
-      "acronym.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["acronym.js"],
+    "test": ["acronym.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,27 +1,27 @@
 {
   "blurb": "Convert a long phrase to its acronym",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "cmccandless",
-    "G-Rath",
     "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "serixscorpio",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["acronym.js"],
-    "test": ["acronym.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "acronym.js"
+    ],
+    "test": [
+      "acronym.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a long phrase to its acronym",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -21,15 +19,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "acronym.js"
-    ],
-    "test": [
-      "acronym.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["acronym.js"],
+    "test": ["acronym.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Convert a long phrase to its acronym",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "cmccandless",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["acronym.js"],
-    "test": ["acronym.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "acronym.js"
+    ],
+    "test": [
+      "acronym.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"

--- a/exercises/practice/acronym/package.json
+++ b/exercises/practice/acronym/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
-  "authors": [
-    "TomPradat"
-  ],
-  "contributors": [
-    "SleeplessByte"
-  ],
+  "authors": ["TomPradat"],
+  "contributors": ["SleeplessByte"],
   "files": {
-    "solution": [
-      "affine-cipher.js"
-    ],
-    "test": [
-      "affine-cipher.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["affine-cipher.js"],
+    "test": ["affine-cipher.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Affine_cipher"

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -1,10 +1,21 @@
 {
   "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
-  "authors": [],
+  "authors": [
+    "TomPradat"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["affine-cipher.js"],
-    "test": ["affine-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "affine-cipher.js"
+    ],
+    "test": [
+      "affine-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Affine_cipher"

--- a/exercises/practice/affine-cipher/package.json
+++ b/exercises/practice/affine-cipher/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,25 +1,25 @@
 {
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
-  "authors": ["javaeeeee"],
+  "authors": [
+    "javaeeeee"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
     "OrthoDex",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "serixscorpio",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["all-your-base.js"],
-    "test": ["all-your-base.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "all-your-base.js"
+    ],
+    "test": [
+      "all-your-base.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
-  "authors": [
-    "javaeeeee"
-  ],
+  "authors": ["javaeeeee"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -20,14 +18,8 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "all-your-base.js"
-    ],
-    "test": [
-      "all-your-base.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["all-your-base.js"],
+    "test": ["all-your-base.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,9 +1,33 @@
 {
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
-  "authors": [],
+  "authors": [
+    "javaeeeee"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "OrthoDex",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["all-your-base.js"],
-    "test": ["all-your-base.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "all-your-base.js"
+    ],
+    "test": [
+      "all-your-base.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
-  "authors": [
-    "javaeeeee"
-  ],
+  "authors": ["javaeeeee"],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -12,14 +10,8 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "all-your-base.js"
-    ],
-    "test": [
-      "all-your-base.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["all-your-base.js"],
+    "test": ["all-your-base.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/all-your-base/package.json
+++ b/exercises/practice/all-your-base/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -14,15 +12,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "allergies.js"
-    ],
-    "test": [
-      "allergies.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["allergies.js"],
+    "test": ["allergies.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Jumpstart Lab Warm-up",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "thanhcng",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["allergies.js"],
-    "test": ["allergies.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "allergies.js"
+    ],
+    "test": [
+      "allergies.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Jumpstart Lab Warm-up",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,28 +1,28 @@
 {
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
     "tejasbubane",
     "thanhcng",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["allergies.js"],
-    "test": ["allergies.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "allergies.js"
+    ],
+    "test": [
+      "allergies.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Jumpstart Lab Warm-up",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -22,15 +20,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "allergies.js"
-    ],
-    "test": [
-      "allergies.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["allergies.js"],
+    "test": ["allergies.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Jumpstart Lab Warm-up",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/allergies/package.json
+++ b/exercises/practice/allergies/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -1,23 +1,24 @@
 {
   "blurb": "Write a function to solve alphametics puzzles.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "slaymance",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["alphametics.js"],
-    "test": ["alphametics.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "alphametics.js"
+    ],
+    "test": [
+      "alphametics.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -1,9 +1,31 @@
 {
   "blurb": "Write a function to solve alphametics puzzles.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "slaymance",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["alphametics.js"],
-    "test": ["alphametics.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "alphametics.js"
+    ],
+    "test": [
+      "alphametics.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Write a function to solve alphametics puzzles.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "rchavarria",
     "slaymance",
@@ -11,14 +9,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "alphametics.js"
-    ],
-    "test": [
-      "alphametics.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["alphametics.js"],
+    "test": ["alphametics.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Write a function to solve alphametics puzzles.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "G-Rath",
     "gargrave",
@@ -18,14 +16,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "alphametics.js"
-    ],
-    "test": [
-      "alphametics.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["alphametics.js"],
+    "test": ["alphametics.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/alphametics/package.json
+++ b/exercises/practice/alphametics/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "amscotti",
     "ankorGH",
@@ -17,15 +15,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "anagram.js"
-    ],
-    "test": [
-      "anagram.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["anagram.js"],
+    "test": ["anagram.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "amscotti",
     "andreasolund",
@@ -24,15 +22,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "anagram.js"
-    ],
-    "test": [
-      "anagram.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["anagram.js"],
+    "test": ["anagram.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,30 +1,31 @@
 {
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "amscotti",
-    "andreasolund",
     "ankorGH",
     "draalger",
-    "G-Rath",
     "gabriel376",
     "gargrave",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["anagram.js"],
-    "test": ["anagram.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "anagram.js"
+    ],
+    "test": [
+      "anagram.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,10 +1,38 @@
 {
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "amscotti",
+    "andreasolund",
+    "ankorGH",
+    "draalger",
+    "G-Rath",
+    "gabriel376",
+    "gargrave",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["anagram.js"],
-    "test": ["anagram.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "anagram.js"
+    ],
+    "test": [
+      "anagram.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/anagram/package.json
+++ b/exercises/practice/anagram/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Determine if a number is an Armstrong number",
-  "authors": [
-    "PakkuDon"
-  ],
+  "authors": ["PakkuDon"],
   "contributors": [
     "ankorGH",
     "gargrave",
@@ -12,15 +10,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "armstrong-numbers.js"
-    ],
-    "test": [
-      "armstrong-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["armstrong-numbers.js"],
+    "test": ["armstrong-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Determine if a number is an Armstrong number",
-  "authors": [
-    "PakkuDon"
-  ],
+  "authors": ["PakkuDon"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -20,15 +18,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "armstrong-numbers.js"
-    ],
-    "test": [
-      "armstrong-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["armstrong-numbers.js"],
+    "test": ["armstrong-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,26 +1,26 @@
 {
   "blurb": "Determine if a number is an Armstrong number",
-  "authors": ["PakkuDon"],
+  "authors": [
+    "PakkuDon"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
     "gargrave",
     "hayashi-ay",
-    "iagocavalcante",
-    "matthewmorgan",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
-    "rpottsoh",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["armstrong-numbers.js"],
-    "test": ["armstrong-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "armstrong-numbers.js"
+    ],
+    "test": [
+      "armstrong-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Determine if a number is an Armstrong number",
-  "authors": [],
+  "authors": [
+    "PakkuDon"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "hayashi-ay",
+    "iagocavalcante",
+    "matthewmorgan",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rpottsoh",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["armstrong-numbers.js"],
-    "test": ["armstrong-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "armstrong-numbers.js"
+    ],
+    "test": [
+      "armstrong-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"

--- a/exercises/practice/armstrong-numbers/package.json
+++ b/exercises/practice/armstrong-numbers/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "Futuro212",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["atbash-cipher.js"],
-    "test": ["atbash-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "atbash-cipher.js"
+    ],
+    "test": [
+      "atbash-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Atbash"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "Futuro212",
     "ovidiu141",
@@ -13,15 +11,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "atbash-cipher.js"
-    ],
-    "test": [
-      "atbash-cipher.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["atbash-cipher.js"],
+    "test": ["atbash-cipher.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Atbash"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,27 +1,27 @@
 {
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "Futuro212",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["atbash-cipher.js"],
-    "test": ["atbash-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "atbash-cipher.js"
+    ],
+    "test": [
+      "atbash-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Atbash"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "Futuro212",
@@ -21,15 +19,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "atbash-cipher.js"
-    ],
-    "test": [
-      "atbash-cipher.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["atbash-cipher.js"],
+    "test": ["atbash-cipher.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Atbash"

--- a/exercises/practice/atbash-cipher/package.json
+++ b/exercises/practice/atbash-cipher/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -1,20 +1,10 @@
 {
   "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!",
-  "authors": [
-    "TomPradat"
-  ],
-  "contributors": [
-    "SleeplessByte"
-  ],
+  "authors": ["TomPradat"],
+  "contributors": ["SleeplessByte"],
   "files": {
-    "solution": [
-      "bank-account.js"
-    ],
-    "test": [
-      "bank-account.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["bank-account.js"],
+    "test": ["bank-account.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -1,9 +1,20 @@
 {
   "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!",
-  "authors": [],
+  "authors": [
+    "TomPradat"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["bank-account.js"],
-    "test": ["bank-account.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "bank-account.js"
+    ],
+    "test": [
+      "bank-account.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/bank-account/package.json
+++ b/exercises/practice/bank-account/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -24,15 +22,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "beer-song.js"
-    ],
-    "test": [
-      "beer-song.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["beer-song.js"],
+    "test": ["beer-song.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Learn to Program by Chris Pine",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,10 +1,38 @@
 {
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "draalger",
+    "Futuro212",
+    "G-Rath",
+    "gargrave",
+    "hayashi-ay",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["beer-song.js"],
-    "test": ["beer-song.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "beer-song.js"
+    ],
+    "test": [
+      "beer-song.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Learn to Program by Chris Pine",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -16,15 +14,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "beer-song.js"
-    ],
-    "test": [
-      "beer-song.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["beer-song.js"],
+    "test": ["beer-song.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Learn to Program by Chris Pine",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,30 +1,30 @@
 {
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "draalger",
     "Futuro212",
-    "G-Rath",
-    "gargrave",
     "hayashi-ay",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["beer-song.js"],
-    "test": ["beer-song.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "beer-song.js"
+    ],
+    "test": [
+      "beer-song.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Learn to Program by Chris Pine",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/beer-song/package.json
+++ b/exercises/practice/beer-song/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Insert and search for numbers in a binary tree.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "Futuro212",
@@ -12,15 +10,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "binary-search-tree.js"
-    ],
-    "test": [
-      "binary-search-tree.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["binary-search-tree.js"],
+    "test": ["binary-search-tree.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Josh Cheek",
   "source_url": "https://twitter.com/josh_cheek"

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Insert and search for numbers in a binary tree.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "Futuro212",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["binary-search-tree.js"],
-    "test": ["binary-search-tree.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "binary-search-tree.js"
+    ],
+    "test": [
+      "binary-search-tree.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Josh Cheek",
   "source_url": "https://twitter.com/josh_cheek"

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -1,26 +1,26 @@
 {
   "blurb": "Insert and search for numbers in a binary tree.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "Futuro212",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["binary-search-tree.js"],
-    "test": ["binary-search-tree.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "binary-search-tree.js"
+    ],
+    "test": [
+      "binary-search-tree.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Josh Cheek",
   "source_url": "https://twitter.com/josh_cheek"

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Insert and search for numbers in a binary tree.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -20,15 +18,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "binary-search-tree.js"
-    ],
-    "test": [
-      "binary-search-tree.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["binary-search-tree.js"],
+    "test": ["binary-search-tree.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Josh Cheek",
   "source_url": "https://twitter.com/josh_cheek"

--- a/exercises/practice/binary-search-tree/package.json
+++ b/exercises/practice/binary-search-tree/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,26 +1,26 @@
 {
   "blurb": "Implement a binary search algorithm.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "Futuro212",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["binary-search.js"],
-    "test": ["binary-search.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "binary-search.js"
+    ],
+    "test": [
+      "binary-search.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Implement a binary search algorithm.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "Futuro212",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["binary-search.js"],
-    "test": ["binary-search.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "binary-search.js"
+    ],
+    "test": [
+      "binary-search.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement a binary search algorithm.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "Futuro212",
@@ -20,15 +18,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "binary-search.js"
-    ],
-    "test": [
-      "binary-search.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["binary-search.js"],
+    "test": ["binary-search.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement a binary search algorithm.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "Futuro212",
     "matthewmorgan",
@@ -12,15 +10,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "binary-search.js"
-    ],
-    "test": [
-      "binary-search.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["binary-search.js"],
+    "test": ["binary-search.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"

--- a/exercises/practice/binary-search/package.json
+++ b/exercises/practice/binary-search/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -20,15 +18,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "binary.js"
-    ],
-    "test": [
-      "binary.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["binary.js"],
+    "test": ["binary.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,26 +1,26 @@
 {
   "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "Futuro212",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["binary.js"],
-    "test": ["binary.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "binary.js"
+    ],
+    "test": [
+      "binary.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "Futuro212",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["binary.js"],
-    "test": ["binary.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "binary.js"
+    ],
+    "test": [
+      "binary.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "Futuro212",
@@ -12,15 +10,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "binary.js"
-    ],
-    "test": [
-      "binary.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["binary.js"],
+    "test": ["binary.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/binary/package.json
+++ b/exercises/practice/binary/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,34 +1,31 @@
 {
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "105ron",
     "amscotti",
-    "andreasolund",
     "austinratcliff",
     "brendan-c",
     "draalger",
-    "G-Rath",
-    "gargrave",
     "hayashi-ay",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "serixscorpio",
     "SleeplessByte",
-    "tejasbubane",
-    "tikaro",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["bob.js"],
-    "test": ["bob.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "bob.js"
+    ],
+    "test": [
+      "bob.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "amscotti",
     "austinratcliff",
@@ -17,15 +15,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "bob.js"
-    ],
-    "test": [
-      "bob.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["bob.js"],
+    "test": ["bob.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "105ron",
     "amscotti",
@@ -28,15 +26,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "bob.js"
-    ],
-    "test": [
-      "bob.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["bob.js"],
+    "test": ["bob.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,10 +1,42 @@
 {
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "105ron",
+    "amscotti",
+    "andreasolund",
+    "austinratcliff",
+    "brendan-c",
+    "draalger",
+    "G-Rath",
+    "gargrave",
+    "hayashi-ay",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "tikaro",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["bob.js"],
-    "test": ["bob.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "bob.js"
+    ],
+    "test": [
+      "bob.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/bob/package.json
+++ b/exercises/practice/bob/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,23 +1,23 @@
 {
   "blurb": "Score a bowling game",
-  "authors": ["trvrfrd"],
+  "authors": [
+    "trvrfrd"
+  ],
   "contributors": [
     "danielj-jordan",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["bowling.js"],
-    "test": ["bowling.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "bowling.js"
+    ],
+    "test": [
+      "bowling.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Bowling Game Kata at but UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,23 +1,11 @@
 {
   "blurb": "Score a bowling game",
-  "authors": [
-    "trvrfrd"
-  ],
-  "contributors": [
-    "danielj-jordan",
-    "SleeplessByte",
-    "tejasbubane"
-  ],
+  "authors": ["trvrfrd"],
+  "contributors": ["danielj-jordan", "SleeplessByte", "tejasbubane"],
   "files": {
-    "solution": [
-      "bowling.js"
-    ],
-    "test": [
-      "bowling.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["bowling.js"],
+    "test": ["bowling.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Bowling Game Kata at but UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Score a bowling game",
-  "authors": [
-    "trvrfrd"
-  ],
+  "authors": ["trvrfrd"],
   "contributors": [
     "danielj-jordan",
     "G-Rath",
@@ -17,15 +15,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "bowling.js"
-    ],
-    "test": [
-      "bowling.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["bowling.js"],
+    "test": ["bowling.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Bowling Game Kata at but UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,10 +1,31 @@
 {
   "blurb": "Score a bowling game",
-  "authors": [],
+  "authors": [
+    "trvrfrd"
+  ],
+  "contributors": [
+    "danielj-jordan",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["bowling.js"],
-    "test": ["bowling.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "bowling.js"
+    ],
+    "test": [
+      "bowling.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Bowling Game Kata at but UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"

--- a/exercises/practice/bowling/package.json
+++ b/exercises/practice/bowling/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Correctly determine change to be given using the least number of coins",
-  "authors": [
-    "RobinCsl"
-  ],
+  "authors": ["RobinCsl"],
   "contributors": [
     "adamxtokyo",
     "rchavarria",
@@ -12,15 +10,9 @@
     "whatcoda"
   ],
   "files": {
-    "solution": [
-      "change.js"
-    ],
-    "test": [
-      "change.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["change.js"],
+    "test": ["change.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Software Craftsmanship - Coin Change Kata",
   "source_url": "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata"

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Correctly determine change to be given using the least number of coins",
-  "authors": [
-    "RobinCsl"
-  ],
+  "authors": ["RobinCsl"],
   "contributors": [
     "adamxtokyo",
     "G-Rath",
@@ -20,15 +18,9 @@
     "whatcoda"
   ],
   "files": {
-    "solution": [
-      "change.js"
-    ],
-    "test": [
-      "change.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["change.js"],
+    "test": ["change.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Software Craftsmanship - Coin Change Kata",
   "source_url": "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata"

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -1,26 +1,26 @@
 {
   "blurb": "Correctly determine change to be given using the least number of coins",
-  "authors": ["RobinCsl"],
+  "authors": [
+    "RobinCsl"
+  ],
   "contributors": [
     "adamxtokyo",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "SleeplessByte",
     "tejasbubane",
     "TomPradat",
-    "Tyresius92",
     "whatcoda"
   ],
   "files": {
-    "solution": ["change.js"],
-    "test": ["change.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "change.js"
+    ],
+    "test": [
+      "change.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Software Craftsmanship - Coin Change Kata",
   "source_url": "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata"

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Correctly determine change to be given using the least number of coins",
-  "authors": [],
+  "authors": [
+    "RobinCsl"
+  ],
+  "contributors": [
+    "adamxtokyo",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "TomPradat",
+    "Tyresius92",
+    "whatcoda"
+  ],
   "files": {
-    "solution": ["change.js"],
-    "test": ["change.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "change.js"
+    ],
+    "test": [
+      "change.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Software Craftsmanship - Coin Change Kata",
   "source_url": "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata"

--- a/exercises/practice/change/package.json
+++ b/exercises/practice/change/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "diego-caceres",
     "ramitmittal",
@@ -15,15 +13,9 @@
     "yanick"
   ],
   "files": {
-    "solution": [
-      "circular-buffer.js"
-    ],
-    "test": [
-      "circular-buffer.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["circular-buffer.js"],
+    "test": ["circular-buffer.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Circular_buffer"

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -1,10 +1,37 @@
 {
   "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "diego-caceres",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "ramitmittal",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "TomPradat",
+    "trvrfrd",
+    "Tyresius92",
+    "yanick"
+  ],
   "files": {
-    "solution": ["circular-buffer.js"],
-    "test": ["circular-buffer.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "circular-buffer.js"
+    ],
+    "test": [
+      "circular-buffer.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Circular_buffer"

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -1,15 +1,10 @@
 {
   "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "diego-caceres",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "ramitmittal",
     "rchavarria",
     "ryanplusplus",
@@ -17,13 +12,18 @@
     "tejasbubane",
     "TomPradat",
     "trvrfrd",
-    "Tyresius92",
     "yanick"
   ],
   "files": {
-    "solution": ["circular-buffer.js"],
-    "test": ["circular-buffer.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "circular-buffer.js"
+    ],
+    "test": [
+      "circular-buffer.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Circular_buffer"

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "diego-caceres",
@@ -23,15 +21,9 @@
     "yanick"
   ],
   "files": {
-    "solution": [
-      "circular-buffer.js"
-    ],
-    "test": [
-      "circular-buffer.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["circular-buffer.js"],
+    "test": ["circular-buffer.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Circular_buffer"

--- a/exercises/practice/circular-buffer/package.json
+++ b/exercises/practice/circular-buffer/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement a clock that handles times without dates.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "ovidiu141",
@@ -14,15 +12,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "clock.js"
-    ],
-    "test": [
-      "clock.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["clock.js"],
+    "test": ["clock.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Pairing session with Erin Drummond",
   "source_url": "https://twitter.com/ebdrummond"

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Implement a clock that handles times without dates.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["clock.js"],
-    "test": ["clock.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "clock.js"
+    ],
+    "test": [
+      "clock.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Pairing session with Erin Drummond",
   "source_url": "https://twitter.com/ebdrummond"

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement a clock that handles times without dates.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -21,15 +19,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "clock.js"
-    ],
-    "test": [
-      "clock.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["clock.js"],
+    "test": ["clock.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Pairing session with Erin Drummond",
   "source_url": "https://twitter.com/ebdrummond"

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,16 +1,11 @@
 {
   "blurb": "Implement a clock that handles times without dates.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
@@ -19,9 +14,15 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["clock.js"],
-    "test": ["clock.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "clock.js"
+    ],
+    "test": [
+      "clock.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Pairing session with Erin Drummond",
   "source_url": "https://twitter.com/ebdrummond"

--- a/exercises/practice/clock/package.json
+++ b/exercises/practice/clock/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,10 +1,31 @@
 {
   "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "authors": [],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["collatz-conjecture.js"],
-    "test": ["collatz-conjecture.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "collatz-conjecture.js"
+    ],
+    "test": [
+      "collatz-conjecture.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -17,15 +17,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "collatz-conjecture.js"
-    ],
-    "test": [
-      "collatz-conjecture.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["collatz-conjecture.js"],
+    "test": ["collatz-conjecture.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -3,23 +3,20 @@
   "authors": [],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["collatz-conjecture.js"],
-    "test": ["collatz-conjecture.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "collatz-conjecture.js"
+    ],
+    "test": [
+      "collatz-conjecture.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,22 +1,11 @@
 {
   "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "authors": [],
-  "contributors": [
-    "ankorGH",
-    "rchavarria",
-    "SleeplessByte",
-    "xarxziux"
-  ],
+  "contributors": ["ankorGH", "rchavarria", "SleeplessByte", "xarxziux"],
   "files": {
-    "solution": [
-      "collatz-conjecture.js"
-    ],
-    "test": [
-      "collatz-conjecture.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["collatz-conjecture.js"],
+    "test": ["collatz-conjecture.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"

--- a/exercises/practice/collatz-conjecture/package.json
+++ b/exercises/practice/collatz-conjecture/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Implement complex numbers.",
-  "authors": [],
+  "authors": [
+    "MattH-be"
+  ],
+  "contributors": [
+    "ankorGH",
+    "burennto",
+    "cmccandless",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rpottsoh",
+    "SleeplessByte",
+    "tejasbubane",
+    "trvrfrd",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["complex-numbers.js"],
-    "test": ["complex-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "complex-numbers.js"
+    ],
+    "test": [
+      "complex-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Complex_number"

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement complex numbers.",
-  "authors": [
-    "MattH-be"
-  ],
+  "authors": ["MattH-be"],
   "contributors": [
     "ankorGH",
     "burennto",
@@ -20,15 +18,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "complex-numbers.js"
-    ],
-    "test": [
-      "complex-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["complex-numbers.js"],
+    "test": ["complex-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Complex_number"

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -1,26 +1,26 @@
 {
   "blurb": "Implement complex numbers.",
-  "authors": ["MattH-be"],
+  "authors": [
+    "MattH-be"
+  ],
   "contributors": [
     "ankorGH",
     "burennto",
     "cmccandless",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
-    "rpottsoh",
     "SleeplessByte",
     "tejasbubane",
-    "trvrfrd",
-    "Tyresius92"
+    "trvrfrd"
   ],
   "files": {
-    "solution": ["complex-numbers.js"],
-    "test": ["complex-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "complex-numbers.js"
+    ],
+    "test": [
+      "complex-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Complex_number"

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement complex numbers.",
-  "authors": [
-    "MattH-be"
-  ],
+  "authors": ["MattH-be"],
   "contributors": [
     "ankorGH",
     "burennto",
@@ -12,15 +10,9 @@
     "trvrfrd"
   ],
   "files": {
-    "solution": [
-      "complex-numbers.js"
-    ],
-    "test": [
-      "complex-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["complex-numbers.js"],
+    "test": ["complex-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Complex_number"

--- a/exercises/practice/complex-numbers/package.json
+++ b/exercises/practice/complex-numbers/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Compute the result for a game of Hex / Polygon",
-  "authors": [
-    "arthurchipdean"
-  ],
+  "authors": ["arthurchipdean"],
   "contributors": [
     "diego-caceres",
     "G-Rath",
@@ -20,14 +18,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "connect.js"
-    ],
-    "test": [
-      "connect.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["connect.js"],
+    "test": ["connect.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Compute the result for a game of Hex / Polygon",
-  "authors": [
-    "arthurchipdean"
-  ],
+  "authors": ["arthurchipdean"],
   "contributors": [
     "diego-caceres",
     "matthewmorgan",
@@ -12,14 +10,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "connect.js"
-    ],
-    "test": [
-      "connect.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["connect.js"],
+    "test": ["connect.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -1,9 +1,33 @@
 {
   "blurb": "Compute the result for a game of Hex / Polygon",
-  "authors": [],
+  "authors": [
+    "arthurchipdean"
+  ],
+  "contributors": [
+    "diego-caceres",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "joeljuca",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["connect.js"],
-    "test": ["connect.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "connect.js"
+    ],
+    "test": [
+      "connect.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -1,25 +1,25 @@
 {
   "blurb": "Compute the result for a game of Hex / Polygon",
-  "authors": ["arthurchipdean"],
+  "authors": [
+    "arthurchipdean"
+  ],
   "contributors": [
     "diego-caceres",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "joeljuca",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["connect.js"],
-    "test": ["connect.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "connect.js"
+    ],
+    "test": [
+      "connect.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/connect/package.json
+++ b/exercises/practice/connect/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Implement the classic method for composing secret messages called a square code.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "diego-caceres",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "ntshcalleia",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "rpottsoh",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["crypto-square.js"],
-    "test": ["crypto-square.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "crypto-square.js"
+    ],
+    "test": [
+      "crypto-square.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement the classic method for composing secret messages called a square code.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "diego-caceres",
@@ -21,15 +19,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "crypto-square.js"
-    ],
-    "test": [
-      "crypto-square.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["crypto-square.js"],
+    "test": ["crypto-square.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement the classic method for composing secret messages called a square code.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "diego-caceres",
     "ntshcalleia",
@@ -12,15 +10,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "crypto-square.js"
-    ],
-    "test": [
-      "crypto-square.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["crypto-square.js"],
+    "test": ["crypto-square.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,27 +1,26 @@
 {
   "blurb": "Implement the classic method for composing secret messages called a square code.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "diego-caceres",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "ntshcalleia",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
-    "rpottsoh",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["crypto-square.js"],
-    "test": ["crypto-square.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "crypto-square.js"
+    ],
+    "test": [
+      "crypto-square.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/crypto-square/package.json
+++ b/exercises/practice/crypto-square/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -1,28 +1,26 @@
 {
   "blurb": "Create a custom set type.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "apapirovski",
-    "ErikSchierboom",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "javaeeeee",
-    "lantran",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["custom-set.js"],
-    "test": ["custom-set.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "custom-set.js"
+    ],
+    "test": [
+      "custom-set.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Create a custom set type.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -23,14 +21,8 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "custom-set.js"
-    ],
-    "test": [
-      "custom-set.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["custom-set.js"],
+    "test": ["custom-set.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Create a custom set type.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "apapirovski",
@@ -13,14 +11,8 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "custom-set.js"
-    ],
-    "test": [
-      "custom-set.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["custom-set.js"],
+    "test": ["custom-set.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -1,9 +1,36 @@
 {
   "blurb": "Create a custom set type.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "apapirovski",
+    "ErikSchierboom",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "javaeeeee",
+    "lantran",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["custom-set.js"],
-    "test": ["custom-set.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "custom-set.js"
+    ],
+    "test": [
+      "custom-set.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/custom-set/package.json
+++ b/exercises/practice/custom-set/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,10 +1,28 @@
 {
   "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
-  "authors": [],
+  "authors": [
+    "ramadis"
+  ],
+  "contributors": [
+    "ankorGH",
+    "d-vail",
+    "G-Rath",
+    "ovidiu141",
+    "paparomeo",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["darts.js"],
-    "test": ["darts.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "darts.js"
+    ],
+    "test": [
+      "darts.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
-  "authors": [
-    "ramadis"
-  ],
+  "authors": ["ramadis"],
   "contributors": [
     "ankorGH",
     "d-vail",
@@ -11,15 +9,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "darts.js"
-    ],
-    "test": [
-      "darts.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["darts.js"],
+    "test": ["darts.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,20 +1,25 @@
 {
   "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
-  "authors": ["ramadis"],
+  "authors": [
+    "ramadis"
+  ],
   "contributors": [
     "ankorGH",
     "d-vail",
-    "G-Rath",
     "ovidiu141",
-    "paparomeo",
     "SleeplessByte",
-    "tejasbubane",
     "Tyresius92"
   ],
   "files": {
-    "solution": ["darts.js"],
-    "test": ["darts.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "darts.js"
+    ],
+    "test": [
+      "darts.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
-  "authors": [
-    "ramadis"
-  ],
+  "authors": ["ramadis"],
   "contributors": [
     "ankorGH",
     "d-vail",
@@ -14,15 +12,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "darts.js"
-    ],
-    "test": [
-      "darts.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["darts.js"],
+    "test": ["darts.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/darts/package.json
+++ b/exercises/practice/darts/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -11,15 +11,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "diamond.js"
-    ],
-    "test": [
-      "diamond.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["diamond.js"],
+    "test": ["diamond.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Seb Rose",
   "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -3,25 +3,23 @@
   "authors": [],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
     "hayashi-ay",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
-    "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["diamond.js"],
-    "test": ["diamond.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "diamond.js"
+    ],
+    "test": [
+      "diamond.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Seb Rose",
   "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -19,15 +19,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "diamond.js"
-    ],
-    "test": [
-      "diamond.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["diamond.js"],
+    "test": ["diamond.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Seb Rose",
   "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -1,10 +1,33 @@
 {
   "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
   "authors": [],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "hayashi-ay",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["diamond.js"],
-    "test": ["diamond.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "diamond.js"
+    ],
+    "test": [
+      "diamond.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Seb Rose",
   "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"

--- a/exercises/practice/diamond/package.json
+++ b/exercises/practice/diamond/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "hayashi-ay",
@@ -14,15 +12,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "difference-of-squares.js"
-    ],
-    "test": [
-      "difference-of-squares.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["difference-of-squares.js"],
+    "test": ["difference-of-squares.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -22,15 +20,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "difference-of-squares.js"
-    ],
-    "test": [
-      "difference-of-squares.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["difference-of-squares.js"],
+    "test": ["difference-of-squares.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "hayashi-ay",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "Scientifica96",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["difference-of-squares.js"],
-    "test": ["difference-of-squares.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "difference-of-squares.js"
+    ],
+    "test": [
+      "difference-of-squares.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,28 +1,28 @@
 {
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
     "hayashi-ay",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "Scientifica96",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["difference-of-squares.js"],
-    "test": ["difference-of-squares.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "difference-of-squares.js"
+    ],
+    "test": [
+      "difference-of-squares.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6"

--- a/exercises/practice/difference-of-squares/package.json
+++ b/exercises/practice/difference-of-squares/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -1,10 +1,32 @@
 {
   "blurb": "Diffie-Hellman key exchange.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["diffie-hellman.js"],
-    "test": ["diffie-hellman.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "diffie-hellman.js"
+    ],
+    "test": [
+      "diffie-hellman.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia, 1024 bit key from www.cryptopp.com/wiki.",
   "source_url": "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -1,24 +1,25 @@
 {
   "blurb": "Diffie-Hellman key exchange.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "serixscorpio",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["diffie-hellman.js"],
-    "test": ["diffie-hellman.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "diffie-hellman.js"
+    ],
+    "test": [
+      "diffie-hellman.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia, 1024 bit key from www.cryptopp.com/wiki.",
   "source_url": "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Diffie-Hellman key exchange.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -11,15 +9,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "diffie-hellman.js"
-    ],
-    "test": [
-      "diffie-hellman.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["diffie-hellman.js"],
+    "test": ["diffie-hellman.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia, 1024 bit key from www.cryptopp.com/wiki.",
   "source_url": "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Diffie-Hellman key exchange.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -18,15 +16,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "diffie-hellman.js"
-    ],
-    "test": [
-      "diffie-hellman.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["diffie-hellman.js"],
+    "test": ["diffie-hellman.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia, 1024 bit key from www.cryptopp.com/wiki.",
   "source_url": "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"

--- a/exercises/practice/diffie-hellman/package.json
+++ b/exercises/practice/diffie-hellman/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/dnd-character/.meta/config.json
+++ b/exercises/practice/dnd-character/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Randomly generate Dungeons & Dragons characters",
-  "authors": [
-    "Tyresius92"
-  ],
+  "authors": ["Tyresius92"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -12,15 +10,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "dnd-character.js"
-    ],
-    "test": [
-      "dnd-character.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["dnd-character.js"],
+    "test": ["dnd-character.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Simon Shine, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"

--- a/exercises/practice/dnd-character/.meta/config.json
+++ b/exercises/practice/dnd-character/.meta/config.json
@@ -1,10 +1,26 @@
 {
   "blurb": "Randomly generate Dungeons & Dragons characters",
-  "authors": [],
+  "authors": [
+    "Tyresius92"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "hayashi-ay",
+    "paparomeo",
+    "SleeplessByte",
+    "tejasbubane"
+  ],
   "files": {
-    "solution": ["dnd-character.js"],
-    "test": ["dnd-character.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "dnd-character.js"
+    ],
+    "test": [
+      "dnd-character.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Simon Shine, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"

--- a/exercises/practice/dnd-character/.meta/config.json
+++ b/exercises/practice/dnd-character/.meta/config.json
@@ -1,18 +1,23 @@
 {
   "blurb": "Randomly generate Dungeons & Dragons characters",
-  "authors": ["Tyresius92"],
+  "authors": [
+    "Tyresius92"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
     "hayashi-ay",
-    "paparomeo",
-    "SleeplessByte",
-    "tejasbubane"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["dnd-character.js"],
-    "test": ["dnd-character.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "dnd-character.js"
+    ],
+    "test": [
+      "dnd-character.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Simon Shine, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"

--- a/exercises/practice/dnd-character/.meta/config.json
+++ b/exercises/practice/dnd-character/.meta/config.json
@@ -1,23 +1,11 @@
 {
   "blurb": "Randomly generate Dungeons & Dragons characters",
-  "authors": [
-    "Tyresius92"
-  ],
-  "contributors": [
-    "ankorGH",
-    "hayashi-ay",
-    "SleeplessByte"
-  ],
+  "authors": ["Tyresius92"],
+  "contributors": ["ankorGH", "hayashi-ay", "SleeplessByte"],
   "files": {
-    "solution": [
-      "dnd-character.js"
-    ],
-    "test": [
-      "dnd-character.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["dnd-character.js"],
+    "test": ["dnd-character.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Simon Shine, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"

--- a/exercises/practice/dnd-character/package.json
+++ b/exercises/practice/dnd-character/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -1,10 +1,20 @@
 {
   "blurb": "Make a chain of dominoes.",
-  "authors": ["chauchakching"],
-  "contributors": ["SleeplessByte", "tejasbubane"],
+  "authors": [
+    "chauchakching"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["dominoes.js"],
-    "test": ["dominoes.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "dominoes.js"
+    ],
+    "test": [
+      "dominoes.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -1,20 +1,10 @@
 {
   "blurb": "Make a chain of dominoes.",
-  "authors": [
-    "chauchakching"
-  ],
-  "contributors": [
-    "SleeplessByte"
-  ],
+  "authors": ["chauchakching"],
+  "contributors": ["SleeplessByte"],
   "files": {
-    "solution": [
-      "dominoes.js"
-    ],
-    "test": [
-      "dominoes.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["dominoes.js"],
+    "test": ["dominoes.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -1,9 +1,21 @@
 {
   "blurb": "Make a chain of dominoes.",
-  "authors": [],
+  "authors": [
+    "chauchakching"
+  ],
+  "contributors": [
+    "SleeplessByte",
+    "tejasbubane"
+  ],
   "files": {
-    "solution": ["dominoes.js"],
-    "test": ["dominoes.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "dominoes.js"
+    ],
+    "test": [
+      "dominoes.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -1,21 +1,10 @@
 {
   "blurb": "Make a chain of dominoes.",
-  "authors": [
-    "chauchakching"
-  ],
-  "contributors": [
-    "SleeplessByte",
-    "tejasbubane"
-  ],
+  "authors": ["chauchakching"],
+  "contributors": ["SleeplessByte", "tejasbubane"],
   "files": {
-    "solution": [
-      "dominoes.js"
-    ],
-    "test": [
-      "dominoes.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["dominoes.js"],
+    "test": ["dominoes.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/dominoes/package.json
+++ b/exercises/practice/dominoes/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,29 +1,29 @@
 {
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "draalger",
-    "G-Rath",
-    "gargrave",
     "hayashi-ay",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
     "tejasbubane",
-    "trvrfrd",
-    "Tyresius92"
+    "trvrfrd"
   ],
   "files": {
-    "solution": ["etl.js"],
-    "test": ["etl.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "etl.js"
+    ],
+    "test": [
+      "etl.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Jumpstart Lab team",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,10 +1,37 @@
 {
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "draalger",
+    "G-Rath",
+    "gargrave",
+    "hayashi-ay",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "trvrfrd",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["etl.js"],
-    "test": ["etl.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "etl.js"
+    ],
+    "test": [
+      "etl.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Jumpstart Lab team",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -15,15 +13,9 @@
     "trvrfrd"
   ],
   "files": {
-    "solution": [
-      "etl.js"
-    ],
-    "test": [
-      "etl.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["etl.js"],
+    "test": ["etl.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Jumpstart Lab team",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -23,15 +21,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "etl.js"
-    ],
-    "test": [
-      "etl.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["etl.js"],
+    "test": ["etl.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Jumpstart Lab team",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/etl/package.json
+++ b/exercises/practice/etl/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,25 +1,26 @@
 {
   "blurb": "Take a nested list and return a single list with all values except nil/null",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
     "gabriel376",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["flatten-array.js"],
-    "test": ["flatten-array.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "flatten-array.js"
+    ],
+    "test": [
+      "flatten-array.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Interview Question",
   "source_url": "https://reference.wolfram.com/language/ref/Flatten.html"

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Take a nested list and return a single list with all values except nil/null",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -19,15 +17,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "flatten-array.js"
-    ],
-    "test": [
-      "flatten-array.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["flatten-array.js"],
+    "test": ["flatten-array.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Interview Question",
   "source_url": "https://reference.wolfram.com/language/ref/Flatten.html"

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,10 +1,33 @@
 {
   "blurb": "Take a nested list and return a single list with all values except nil/null",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gabriel376",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["flatten-array.js"],
-    "test": ["flatten-array.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "flatten-array.js"
+    ],
+    "test": [
+      "flatten-array.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Interview Question",
   "source_url": "https://reference.wolfram.com/language/ref/Flatten.html"

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Take a nested list and return a single list with all values except nil/null",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "gabriel376",
@@ -12,15 +10,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "flatten-array.js"
-    ],
-    "test": [
-      "flatten-array.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["flatten-array.js"],
+    "test": ["flatten-array.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Interview Question",
   "source_url": "https://reference.wolfram.com/language/ref/Flatten.html"

--- a/exercises/practice/flatten-array/package.json
+++ b/exercises/practice/flatten-array/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -14,15 +12,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "food-chain.js"
-    ],
-    "test": [
-      "food-chain.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["food-chain.js"],
+    "test": ["food-chain.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -22,15 +20,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "food-chain.js"
-    ],
-    "test": [
-      "food-chain.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["food-chain.js"],
+    "test": ["food-chain.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -1,28 +1,28 @@
 {
   "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "draalger",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["food-chain.js"],
-    "test": ["food-chain.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "food-chain.js"
+    ],
+    "test": [
+      "food-chain.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "draalger",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["food-chain.js"],
-    "test": ["food-chain.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "food-chain.js"
+    ],
+    "test": [
+      "food-chain.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"

--- a/exercises/practice/food-chain/package.json
+++ b/exercises/practice/food-chain/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -1,9 +1,31 @@
 {
   "blurb": "Implement an evaluator for a very simple subset of Forth",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "brendanmckeown",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "paparomeo",
+    "PSalant726",
+    "rpottsoh",
+    "slaymance",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["forth.js"],
-    "test": ["forth.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "forth.js"
+    ],
+    "test": [
+      "forth.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement an evaluator for a very simple subset of Forth",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "brendanmckeown",
     "slaymance",
@@ -11,14 +9,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "forth.js"
-    ],
-    "test": [
-      "forth.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["forth.js"],
+    "test": ["forth.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -1,23 +1,24 @@
 {
   "blurb": "Implement an evaluator for a very simple subset of Forth",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "brendanmckeown",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "paparomeo",
-    "PSalant726",
-    "rpottsoh",
     "slaymance",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["forth.js"],
-    "test": ["forth.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "forth.js"
+    ],
+    "test": [
+      "forth.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement an evaluator for a very simple subset of Forth",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "brendanmckeown",
     "G-Rath",
@@ -18,14 +16,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "forth.js"
-    ],
-    "test": [
-      "forth.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["forth.js"],
+    "test": ["forth.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/forth/package.json
+++ b/exercises/practice/forth/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,29 +1,29 @@
 {
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "draalger",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
     "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
     "trvrfrd",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["gigasecond.js"],
-    "test": ["gigasecond.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "gigasecond.js"
+    ],
+    "test": [
+      "gigasecond.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -23,15 +21,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "gigasecond.js"
-    ],
-    "test": [
-      "gigasecond.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["gigasecond.js"],
+    "test": ["gigasecond.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,10 +1,37 @@
 {
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "draalger",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "trvrfrd",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["gigasecond.js"],
-    "test": ["gigasecond.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "gigasecond.js"
+    ],
+    "test": [
+      "gigasecond.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -15,15 +13,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "gigasecond.js"
-    ],
-    "test": [
-      "gigasecond.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["gigasecond.js"],
+    "test": ["gigasecond.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"

--- a/exercises/practice/gigasecond/package.json
+++ b/exercises/practice/gigasecond/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,10 +1,39 @@
 {
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "draalger",
+    "ee7",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "mgmatola",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "StevenACoffman",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["grade-school.js"],
-    "test": ["grade-school.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "grade-school.js"
+    ],
+    "test": [
+      "grade-school.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A pairing session with Phil Battos at gSchool",
   "source_url": "http://gschool.it"

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -16,15 +14,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "grade-school.js"
-    ],
-    "test": [
-      "grade-school.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["grade-school.js"],
+    "test": ["grade-school.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A pairing session with Phil Battos at gSchool",
   "source_url": "http://gschool.it"

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,31 +1,30 @@
 {
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "draalger",
     "ee7",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
     "mgmatola",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
     "StevenACoffman",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["grade-school.js"],
-    "test": ["grade-school.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "grade-school.js"
+    ],
+    "test": [
+      "grade-school.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A pairing session with Phil Battos at gSchool",
   "source_url": "http://gschool.it"

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -25,15 +23,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "grade-school.js"
-    ],
-    "test": [
-      "grade-school.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["grade-school.js"],
+    "test": ["grade-school.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A pairing session with Phil Battos at gSchool",
   "source_url": "http://gschool.it"

--- a/exercises/practice/grade-school/package.json
+++ b/exercises/practice/grade-school/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,29 +1,30 @@
 {
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "drericrobinson",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
     "ovidiu141",
     "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["grains.js"],
-    "test": ["grains.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "grains.js"
+    ],
+    "test": [
+      "grains.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "JavaRanch Cattle Drive, exercise 6",
   "source_url": "http://www.javaranch.com/grains.jsp"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -23,15 +21,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "grains.js"
-    ],
-    "test": [
-      "grains.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["grains.js"],
+    "test": ["grains.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "JavaRanch Cattle Drive, exercise 6",
   "source_url": "http://www.javaranch.com/grains.jsp"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,10 +1,37 @@
 {
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "drericrobinson",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["grains.js"],
-    "test": ["grains.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "grains.js"
+    ],
+    "test": [
+      "grains.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "JavaRanch Cattle Drive, exercise 6",
   "source_url": "http://www.javaranch.com/grains.jsp"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "drericrobinson",
@@ -16,15 +14,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "grains.js"
-    ],
-    "test": [
-      "grains.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["grains.js"],
+    "test": ["grains.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "JavaRanch Cattle Drive, exercise 6",
   "source_url": "http://www.javaranch.com/grains.jsp"

--- a/exercises/practice/grains/package.json
+++ b/exercises/practice/grains/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -1,22 +1,11 @@
 {
   "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",
-  "authors": [
-    "TomPradat"
-  ],
-  "contributors": [
-    "iHiD",
-    "SleeplessByte"
-  ],
+  "authors": ["TomPradat"],
+  "contributors": ["iHiD", "SleeplessByte"],
   "files": {
-    "solution": [
-      "grep.js"
-    ],
-    "test": [
-      "grep.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["grep.js"],
+    "test": ["grep.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Conversation with Nate Foster.",
   "source_url": "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -1,24 +1,11 @@
 {
   "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",
-  "authors": [
-    "TomPradat"
-  ],
-  "contributors": [
-    "iHiD",
-    "paparomeo",
-    "SleeplessByte",
-    "tejasbubane"
-  ],
+  "authors": ["TomPradat"],
+  "contributors": ["iHiD", "paparomeo", "SleeplessByte", "tejasbubane"],
   "files": {
-    "solution": [
-      "grep.js"
-    ],
-    "test": [
-      "grep.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["grep.js"],
+    "test": ["grep.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Conversation with Nate Foster.",
   "source_url": "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -1,11 +1,22 @@
 {
   "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",
-  "authors": ["TomPradat"],
-  "contributors": ["iHiD", "paparomeo", "SleeplessByte", "tejasbubane"],
+  "authors": [
+    "TomPradat"
+  ],
+  "contributors": [
+    "iHiD",
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["grep.js"],
-    "test": ["grep.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "grep.js"
+    ],
+    "test": [
+      "grep.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Conversation with Nate Foster.",
   "source_url": "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -1,10 +1,24 @@
 {
   "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",
-  "authors": [],
+  "authors": [
+    "TomPradat"
+  ],
+  "contributors": [
+    "iHiD",
+    "paparomeo",
+    "SleeplessByte",
+    "tejasbubane"
+  ],
   "files": {
-    "solution": ["grep.js"],
-    "test": ["grep.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "grep.js"
+    ],
+    "test": [
+      "grep.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Conversation with Nate Foster.",
   "source_url": "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"

--- a/exercises/practice/grep/package.json
+++ b/exercises/practice/grep/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -24,15 +22,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "hamming.js"
-    ],
-    "test": [
-      "hamming.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["hamming.js"],
+    "test": ["hamming.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,30 +1,29 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "draalger",
-    "G-Rath",
     "gabriel376",
-    "gargrave",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
-    "rpottsoh",
     "ryanplusplus",
     "serixscorpio",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["hamming.js"],
-    "test": ["hamming.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "hamming.js"
+    ],
+    "test": [
+      "hamming.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -15,15 +13,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "hamming.js"
-    ],
-    "test": [
-      "hamming.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["hamming.js"],
+    "test": ["hamming.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,10 +1,38 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "draalger",
+    "G-Rath",
+    "gabriel376",
+    "gargrave",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rpottsoh",
+    "ryanplusplus",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["hamming.js"],
-    "test": ["hamming.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "hamming.js"
+    ],
+    "test": [
+      "hamming.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/hamming/package.json
+++ b/exercises/practice/hamming/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "austinratcliff",
     "designfrontier",
@@ -14,15 +12,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "hello-world.js"
-    ],
-    "test": [
-      "hello-world.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["hello-world.js"],
+    "test": ["hello-world.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "austinratcliff",
+    "designfrontier",
+    "draalger",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["hello-world.js"],
-    "test": ["hello-world.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "hello-world.js"
+    ],
+    "test": [
+      "hello-world.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,28 +1,28 @@
 {
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "austinratcliff",
     "designfrontier",
     "draalger",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["hello-world.js"],
-    "test": ["hello-world.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "hello-world.js"
+    ],
+    "test": [
+      "hello-world.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "austinratcliff",
@@ -22,15 +20,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "hello-world.js"
-    ],
-    "test": [
-      "hello-world.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["hello-world.js"],
+    "test": ["hello-world.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/practice/hello-world/package.json
+++ b/exercises/practice/hello-world/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "smb26",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["hexadecimal.js"],
-    "test": ["hexadecimal.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "hexadecimal.js"
+    ],
+    "test": [
+      "hexadecimal.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/examples/NumberBases.html"

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -12,15 +10,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "hexadecimal.js"
-    ],
-    "test": [
-      "hexadecimal.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["hexadecimal.js"],
+    "test": ["hexadecimal.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/examples/NumberBases.html"

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -21,15 +19,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "hexadecimal.js"
-    ],
-    "test": [
-      "hexadecimal.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["hexadecimal.js"],
+    "test": ["hexadecimal.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/examples/NumberBases.html"

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -1,27 +1,26 @@
 {
   "blurb": "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
     "smb26",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["hexadecimal.js"],
-    "test": ["hexadecimal.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "hexadecimal.js"
+    ],
+    "test": [
+      "hexadecimal.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/examples/NumberBases.html"

--- a/exercises/practice/hexadecimal/package.json
+++ b/exercises/practice/hexadecimal/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,21 +1,25 @@
 {
   "blurb": "Manage a player's High Score list",
-  "authors": ["PakkuDon"],
+  "authors": [
+    "PakkuDon"
+  ],
   "contributors": [
     "ankorGH",
     "cmccandless",
     "ffflorian",
-    "G-Rath",
     "hayashi-ay",
-    "paparomeo",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["high-scores.js"],
-    "test": ["high-scores.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "high-scores.js"
+    ],
+    "test": [
+      "high-scores.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Tribute to the eighties' arcade game Frogger"
 }

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Manage a player's High Score list",
-  "authors": [
-    "PakkuDon"
-  ],
+  "authors": ["PakkuDon"],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -15,15 +13,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "high-scores.js"
-    ],
-    "test": [
-      "high-scores.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["high-scores.js"],
+    "test": ["high-scores.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Tribute to the eighties' arcade game Frogger"
 }

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Manage a player's High Score list",
-  "authors": [
-    "PakkuDon"
-  ],
+  "authors": ["PakkuDon"],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -11,15 +9,9 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "high-scores.js"
-    ],
-    "test": [
-      "high-scores.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["high-scores.js"],
+    "test": ["high-scores.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Tribute to the eighties' arcade game Frogger"
 }

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,10 +1,29 @@
 {
   "blurb": "Manage a player's High Score list",
-  "authors": [],
+  "authors": [
+    "PakkuDon"
+  ],
+  "contributors": [
+    "ankorGH",
+    "cmccandless",
+    "ffflorian",
+    "G-Rath",
+    "hayashi-ay",
+    "paparomeo",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["high-scores.js"],
-    "test": ["high-scores.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "high-scores.js"
+    ],
+    "test": [
+      "high-scores.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Tribute to the eighties' arcade game Frogger"
 }

--- a/exercises/practice/high-scores/package.json
+++ b/exercises/practice/high-scores/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",
-  "authors": [
-    "laurmurclar"
-  ],
+  "authors": ["laurmurclar"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -17,15 +15,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "house.js"
-    ],
-    "test": [
-      "house.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["house.js"],
+    "test": ["house.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "British nursery rhyme",
   "source_url": "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -1,10 +1,31 @@
 {
   "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",
-  "authors": [],
+  "authors": [
+    "laurmurclar"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["house.js"],
-    "test": ["house.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "house.js"
+    ],
+    "test": [
+      "house.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "British nursery rhyme",
   "source_url": "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -1,24 +1,11 @@
 {
   "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",
-  "authors": [
-    "laurmurclar"
-  ],
-  "contributors": [
-    "ankorGH",
-    "rchavarria",
-    "SleeplessByte",
-    "tejasbubane"
-  ],
+  "authors": ["laurmurclar"],
+  "contributors": ["ankorGH", "rchavarria", "SleeplessByte", "tejasbubane"],
   "files": {
-    "solution": [
-      "house.js"
-    ],
-    "test": [
-      "house.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["house.js"],
+    "test": ["house.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "British nursery rhyme",
   "source_url": "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -1,23 +1,24 @@
 {
   "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",
-  "authors": ["laurmurclar"],
+  "authors": [
+    "laurmurclar"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["house.js"],
-    "test": ["house.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "house.js"
+    ],
+    "test": [
+      "house.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "British nursery rhyme",
   "source_url": "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"

--- a/exercises/practice/house/package.json
+++ b/exercises/practice/house/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Check if a given string is a valid ISBN-10 number.",
-  "authors": [
-    "MattH-be"
-  ],
+  "authors": ["MattH-be"],
   "contributors": [
     "ankorGH",
     "ovidiu141",
@@ -12,15 +10,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "isbn-verifier.js"
-    ],
-    "test": [
-      "isbn-verifier.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["isbn-verifier.js"],
+    "test": ["isbn-verifier.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",
   "source_url": "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation"

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Check if a given string is a valid ISBN-10 number.",
-  "authors": [],
+  "authors": [
+    "MattH-be"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "pyko",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["isbn-verifier.js"],
-    "test": ["isbn-verifier.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "isbn-verifier.js"
+    ],
+    "test": [
+      "isbn-verifier.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",
   "source_url": "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation"

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Check if a given string is a valid ISBN-10 number.",
-  "authors": [
-    "MattH-be"
-  ],
+  "authors": ["MattH-be"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -20,15 +18,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "isbn-verifier.js"
-    ],
-    "test": [
-      "isbn-verifier.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["isbn-verifier.js"],
+    "test": ["isbn-verifier.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",
   "source_url": "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation"

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,26 +1,26 @@
 {
   "blurb": "Check if a given string is a valid ISBN-10 number.",
-  "authors": ["MattH-be"],
+  "authors": [
+    "MattH-be"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "matthewmorgan",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "pyko",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["isbn-verifier.js"],
-    "test": ["isbn-verifier.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "isbn-verifier.js"
+    ],
+    "test": [
+      "isbn-verifier.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",
   "source_url": "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation"

--- a/exercises/practice/isbn-verifier/package.json
+++ b/exercises/practice/isbn-verifier/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -21,15 +21,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "isogram.js"
-    ],
-    "test": [
-      "isogram.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["isogram.js"],
+    "test": ["isogram.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Isogram"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Determine if a word or phrase is an isogram.",
   "authors": [],
+  "contributors": [
+    "amscotti",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "ovidiu141",
+    "PakkuDon",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["isogram.js"],
-    "test": ["isogram.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "isogram.js"
+    ],
+    "test": [
+      "isogram.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Isogram"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -12,15 +12,9 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "isogram.js"
-    ],
-    "test": [
-      "isogram.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["isogram.js"],
+    "test": ["isogram.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Isogram"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -4,26 +4,23 @@
   "contributors": [
     "amscotti",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
     "ovidiu141",
     "PakkuDon",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
-    "ryanplusplus",
     "serixscorpio",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["isogram.js"],
-    "test": ["isogram.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "isogram.js"
+    ],
+    "test": [
+      "isogram.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Isogram"

--- a/exercises/practice/isogram/package.json
+++ b/exercises/practice/isogram/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -1,26 +1,26 @@
 {
   "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "brendanmckeown",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["kindergarten-garden.js"],
-    "test": ["kindergarten-garden.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "kindergarten-garden.js"
+    ],
+    "test": [
+      "kindergarten-garden.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Random musings during airplane trip.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "brendanmckeown",
     "matthewmorgan",
@@ -12,15 +10,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "kindergarten-garden.js"
-    ],
-    "test": [
-      "kindergarten-garden.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["kindergarten-garden.js"],
+    "test": ["kindergarten-garden.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Random musings during airplane trip.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "brendanmckeown",
@@ -20,15 +18,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "kindergarten-garden.js"
-    ],
-    "test": [
-      "kindergarten-garden.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["kindergarten-garden.js"],
+    "test": ["kindergarten-garden.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Random musings during airplane trip.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "brendanmckeown",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["kindergarten-garden.js"],
-    "test": ["kindergarten-garden.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "kindergarten-garden.js"
+    ],
+    "test": [
+      "kindergarten-garden.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Random musings during airplane trip.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/kindergarten-garden/package.json
+++ b/exercises/practice/kindergarten-garden/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -23,15 +21,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "largest-series-product.js"
-    ],
-    "test": [
-      "largest-series-product.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["largest-series-product.js"],
+    "test": ["largest-series-product.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,29 +1,28 @@
 {
   "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "ovidiu141",
-    "paparomeo",
     "petertseng",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "serixscorpio",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["largest-series-product.js"],
-    "test": ["largest-series-product.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "largest-series-product.js"
+    ],
+    "test": [
+      "largest-series-product.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,10 +1,37 @@
 {
   "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "ovidiu141",
+    "paparomeo",
+    "petertseng",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["largest-series-product.js"],
-    "test": ["largest-series-product.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "largest-series-product.js"
+    ],
+    "test": [
+      "largest-series-product.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "ovidiu141",
@@ -14,15 +12,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "largest-series-product.js"
-    ],
-    "test": [
-      "largest-series-product.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["largest-series-product.js"],
+    "test": ["largest-series-product.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/largest-series-product/package.json
+++ b/exercises/practice/largest-series-product/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,10 +1,38 @@
 {
   "blurb": "Given a year, report if it is a leap year.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "draalger",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "PakkuDon",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tarunvelli",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["leap.js"],
-    "test": ["leap.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "leap.js"
+    ],
+    "test": [
+      "leap.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",
   "source_url": "http://www.javaranch.com/leap.jsp"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a year, report if it is a leap year.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -24,15 +22,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "leap.js"
-    ],
-    "test": [
-      "leap.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["leap.js"],
+    "test": ["leap.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",
   "source_url": "http://www.javaranch.com/leap.jsp"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,30 +1,30 @@
 {
   "blurb": "Given a year, report if it is a leap year.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "draalger",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
     "PakkuDon",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
     "tarunvelli",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["leap.js"],
-    "test": ["leap.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "leap.js"
+    ],
+    "test": [
+      "leap.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",
   "source_url": "http://www.javaranch.com/leap.jsp"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a year, report if it is a leap year.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -16,15 +14,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "leap.js"
-    ],
-    "test": [
-      "leap.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["leap.js"],
+    "test": ["leap.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",
   "source_url": "http://www.javaranch.com/leap.jsp"

--- a/exercises/practice/leap/package.json
+++ b/exercises/practice/leap/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -1,10 +1,39 @@
 {
   "blurb": "Implement a doubly linked list",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "bdjnk",
+    "cmccandless",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "jcshih",
+    "junedev",
+    "lantran",
+    "monte-hayward",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "thanhcng",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["linked-list.js"],
-    "test": ["linked-list.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "linked-list.js"
+    ],
+    "test": [
+      "linked-list.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Classic computer science topic"
 }

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -1,31 +1,30 @@
 {
   "blurb": "Implement a doubly linked list",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "bdjnk",
     "cmccandless",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "jcshih",
     "junedev",
-    "lantran",
     "monte-hayward",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "thanhcng",
-    "Tyresius92"
+    "thanhcng"
   ],
   "files": {
-    "solution": ["linked-list.js"],
-    "test": ["linked-list.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "linked-list.js"
+    ],
+    "test": [
+      "linked-list.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Classic computer science topic"
 }

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement a doubly linked list",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -25,15 +23,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "linked-list.js"
-    ],
-    "test": [
-      "linked-list.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["linked-list.js"],
+    "test": ["linked-list.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Classic computer science topic"
 }

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement a doubly linked list",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "bdjnk",
@@ -16,15 +14,9 @@
     "thanhcng"
   ],
   "files": {
-    "solution": [
-      "linked-list.js"
-    ],
-    "test": [
-      "linked-list.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["linked-list.js"],
+    "test": ["linked-list.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Classic computer science topic"
 }

--- a/exercises/practice/linked-list/package.json
+++ b/exercises/practice/linked-list/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,25 +1,27 @@
 {
   "blurb": "Implement basic list operations",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "archanid",
-    "G-Rath",
-    "gargrave",
     "hayashi-ay",
-    "iagocavalcante",
-    "lantran",
     "paparomeo",
-    "PSalant726",
     "rchavarria",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["list-ops.js"],
-    "test": ["list-ops.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "list-ops.js"
+    ],
+    "test": [
+      "list-ops.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,9 +1,33 @@
 {
   "blurb": "Implement basic list operations",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "ankorGH",
+    "archanid",
+    "G-Rath",
+    "gargrave",
+    "hayashi-ay",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["list-ops.js"],
-    "test": ["list-ops.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "list-ops.js"
+    ],
+    "test": [
+      "list-ops.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement basic list operations",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "archanid",
@@ -20,14 +18,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "list-ops.js"
-    ],
-    "test": [
-      "list-ops.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["list-ops.js"],
+    "test": ["list-ops.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement basic list operations",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "archanid",
@@ -14,14 +12,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "list-ops.js"
-    ],
-    "test": [
-      "list-ops.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["list-ops.js"],
+    "test": ["list-ops.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/list-ops/package.json
+++ b/exercises/practice/list-ops/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "gabriel376",
@@ -14,15 +12,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "luhn.js"
-    ],
-    "test": [
-      "luhn.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["luhn.js"],
+    "test": ["luhn.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Luhn Algorithm on Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -22,15 +20,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "luhn.js"
-    ],
-    "test": [
-      "luhn.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["luhn.js"],
+    "test": ["luhn.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Luhn Algorithm on Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gabriel376",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["luhn.js"],
-    "test": ["luhn.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "luhn.js"
+    ],
+    "test": [
+      "luhn.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Luhn Algorithm on Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,28 +1,28 @@
 {
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
     "gabriel376",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["luhn.js"],
-    "test": ["luhn.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "luhn.js"
+    ],
+    "test": [
+      "luhn.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Luhn Algorithm on Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm"

--- a/exercises/practice/luhn/package.json
+++ b/exercises/practice/luhn/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Make sure the brackets and braces all match.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "Futuro212",
@@ -13,15 +11,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "matching-brackets.js"
-    ],
-    "test": [
-      "matching-brackets.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["matching-brackets.js"],
+    "test": ["matching-brackets.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Ginna Baker"
 }

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,10 +1,37 @@
 {
   "blurb": "Make sure the brackets and braces all match.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "Futuro212",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "rpottsoh",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["matching-brackets.js"],
-    "test": ["matching-brackets.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "matching-brackets.js"
+    ],
+    "test": [
+      "matching-brackets.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Ginna Baker"
 }

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,29 +1,27 @@
 {
   "blurb": "Make sure the brackets and braces all match.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "Futuro212",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
-    "rpottsoh",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["matching-brackets.js"],
-    "test": ["matching-brackets.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "matching-brackets.js"
+    ],
+    "test": [
+      "matching-brackets.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Ginna Baker"
 }

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Make sure the brackets and braces all match.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -23,15 +21,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "matching-brackets.js"
-    ],
-    "test": [
-      "matching-brackets.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["matching-brackets.js"],
+    "test": ["matching-brackets.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Ginna Baker"
 }

--- a/exercises/practice/matching-brackets/package.json
+++ b/exercises/practice/matching-brackets/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -1,30 +1,29 @@
 {
   "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "amscotti",
-    "andreasolund",
     "ankorGH",
     "brendan-c",
     "DagmarTimmreck",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "serixscorpio",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["matrix.js"],
-    "test": ["matrix.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "matrix.js"
+    ],
+    "test": [
+      "matrix.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Warmup to the `saddle-points` warmup.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "amscotti",
     "ankorGH",
@@ -15,15 +13,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "matrix.js"
-    ],
-    "test": [
-      "matrix.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["matrix.js"],
+    "test": ["matrix.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Warmup to the `saddle-points` warmup.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "amscotti",
     "andreasolund",
@@ -24,15 +22,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "matrix.js"
-    ],
-    "test": [
-      "matrix.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["matrix.js"],
+    "test": ["matrix.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Warmup to the `saddle-points` warmup.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -1,10 +1,38 @@
 {
   "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "amscotti",
+    "andreasolund",
+    "ankorGH",
+    "brendan-c",
+    "DagmarTimmreck",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["matrix.js"],
-    "test": ["matrix.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "matrix.js"
+    ],
+    "test": [
+      "matrix.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Warmup to the `saddle-points` warmup.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/matrix/package.json
+++ b/exercises/practice/matrix/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Calculate the date of meetups.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "G-Rath",
@@ -21,15 +19,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "meetup.js"
-    ],
-    "test": [
-      "meetup.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["meetup.js"],
+    "test": ["meetup.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
   "source_url": "https://twitter.com/copiousfreetime"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Calculate the date of meetups.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ovidiu141",
     "rchavarria",
@@ -12,15 +10,9 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "meetup.js"
-    ],
-    "test": [
-      "meetup.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["meetup.js"],
+    "test": ["meetup.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
   "source_url": "https://twitter.com/copiousfreetime"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,27 +1,26 @@
 {
   "blurb": "Calculate the date of meetups.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "rsuttles58",
     "ryanplusplus",
     "serixscorpio",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["meetup.js"],
-    "test": ["meetup.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "meetup.js"
+    ],
+    "test": [
+      "meetup.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
   "source_url": "https://twitter.com/copiousfreetime"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Calculate the date of meetups.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "rsuttles58",
+    "ryanplusplus",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["meetup.js"],
-    "test": ["meetup.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "meetup.js"
+    ],
+    "test": [
+      "meetup.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
   "source_url": "https://twitter.com/copiousfreetime"

--- a/exercises/practice/meetup/package.json
+++ b/exercises/practice/meetup/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Add the numbers to a minesweeper board",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "brendanmckeown",
     "cr0t",
@@ -20,14 +18,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "minesweeper.js"
-    ],
-    "test": [
-      "minesweeper.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["minesweeper.js"],
+    "test": ["minesweeper.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Add the numbers to a minesweeper board",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "brendanmckeown",
     "cr0t",
@@ -12,14 +10,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "minesweeper.js"
-    ],
-    "test": [
-      "minesweeper.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["minesweeper.js"],
+    "test": ["minesweeper.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,25 +1,25 @@
 {
   "blurb": "Add the numbers to a minesweeper board",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "brendanmckeown",
     "cr0t",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "serixscorpio",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["minesweeper.js"],
-    "test": ["minesweeper.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "minesweeper.js"
+    ],
+    "test": [
+      "minesweeper.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,9 +1,33 @@
 {
   "blurb": "Add the numbers to a minesweeper board",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "brendanmckeown",
+    "cr0t",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["minesweeper.js"],
-    "test": ["minesweeper.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "minesweeper.js"
+    ],
+    "test": [
+      "minesweeper.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/minesweeper/package.json
+++ b/exercises/practice/minesweeper/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,28 +1,28 @@
 {
   "blurb": "Given a number n, determine what the nth prime is.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
     "hayashi-ay",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["nth-prime.js"],
-    "test": ["nth-prime.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "nth-prime.js"
+    ],
+    "test": [
+      "nth-prime.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on Problem 7 at Project Euler",
   "source_url": "http://projecteuler.net/problem=7"

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a number n, determine what the nth prime is.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -22,15 +20,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "nth-prime.js"
-    ],
-    "test": [
-      "nth-prime.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["nth-prime.js"],
+    "test": ["nth-prime.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on Problem 7 at Project Euler",
   "source_url": "http://projecteuler.net/problem=7"

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a number n, determine what the nth prime is.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "hayashi-ay",
@@ -14,15 +12,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "nth-prime.js"
-    ],
-    "test": [
-      "nth-prime.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["nth-prime.js"],
+    "test": ["nth-prime.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on Problem 7 at Project Euler",
   "source_url": "http://projecteuler.net/problem=7"

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Given a number n, determine what the nth prime is.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "hayashi-ay",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["nth-prime.js"],
-    "test": ["nth-prime.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "nth-prime.js"
+    ],
+    "test": [
+      "nth-prime.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on Problem 7 at Project Euler",
   "source_url": "http://projecteuler.net/problem=7"

--- a/exercises/practice/nth-prime/package.json
+++ b/exercises/practice/nth-prime/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,24 +1,24 @@
 {
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
-  "authors": ["tarunvelli"],
+  "authors": [
+    "tarunvelli"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
     "hayashi-ay",
-    "iagocavalcante",
-    "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
-    "rpottsoh",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["nucleotide-count.js"],
-    "test": ["nucleotide-count.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "nucleotide-count.js"
+    ],
+    "test": [
+      "nucleotide-count.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,24 +1,11 @@
 {
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
-  "authors": [
-    "tarunvelli"
-  ],
-  "contributors": [
-    "ankorGH",
-    "hayashi-ay",
-    "SleeplessByte",
-    "tejasbubane"
-  ],
+  "authors": ["tarunvelli"],
+  "contributors": ["ankorGH", "hayashi-ay", "SleeplessByte", "tejasbubane"],
   "files": {
-    "solution": [
-      "nucleotide-count.js"
-    ],
-    "test": [
-      "nucleotide-count.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["nucleotide-count.js"],
+    "test": ["nucleotide-count.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,10 +1,32 @@
 {
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
-  "authors": [],
+  "authors": [
+    "tarunvelli"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "hayashi-ay",
+    "iagocavalcante",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rpottsoh",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["nucleotide-count.js"],
-    "test": ["nucleotide-count.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "nucleotide-count.js"
+    ],
+    "test": [
+      "nucleotide-count.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
-  "authors": [
-    "tarunvelli"
-  ],
+  "authors": ["tarunvelli"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -18,15 +16,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "nucleotide-count.js"
-    ],
-    "test": [
-      "nucleotide-count.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["nucleotide-count.js"],
+    "test": ["nucleotide-count.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/"

--- a/exercises/practice/nucleotide-count/package.json
+++ b/exercises/practice/nucleotide-count/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -1,26 +1,25 @@
 {
   "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["ocr-numbers.js"],
-    "test": ["ocr-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "ocr-numbers.js"
+    ],
+    "test": [
+      "ocr-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by the Bank OCR kata",
   "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["ocr-numbers.js"],
-    "test": ["ocr-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "ocr-numbers.js"
+    ],
+    "test": [
+      "ocr-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by the Bank OCR kata",
   "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -11,15 +9,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "ocr-numbers.js"
-    ],
-    "test": [
-      "ocr-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["ocr-numbers.js"],
+    "test": ["ocr-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the Bank OCR kata",
   "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -20,15 +18,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "ocr-numbers.js"
-    ],
-    "test": [
-      "ocr-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["ocr-numbers.js"],
+    "test": ["ocr-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the Bank OCR kata",
   "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"

--- a/exercises/practice/ocr-numbers/package.json
+++ b/exercises/practice/ocr-numbers/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -20,15 +18,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "octal.js"
-    ],
-    "test": [
-      "octal.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["octal.js"],
+    "test": ["octal.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=base+8"

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "msomji",
@@ -12,15 +10,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "octal.js"
-    ],
-    "test": [
-      "octal.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["octal.js"],
+    "test": ["octal.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=base+8"

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -1,26 +1,26 @@
 {
   "blurb": "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "msomji",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["octal.js"],
-    "test": ["octal.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "octal.js"
+    ],
+    "test": [
+      "octal.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=base+8"

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "msomji",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["octal.js"],
-    "test": ["octal.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "octal.js"
+    ],
+    "test": [
+      "octal.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=base+8"

--- a/exercises/practice/octal/package.json
+++ b/exercises/practice/octal/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -1,10 +1,39 @@
 {
   "blurb": "Detect palindrome products in a given range.",
   "authors": [],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "cmccandless",
+    "draalger",
+    "ErikSchierboom",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "javaeeeee",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "smb26",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["palindrome-products.js"],
-    "test": ["palindrome-products.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "palindrome-products.js"
+    ],
+    "test": [
+      "palindrome-products.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Problem 4 at Project Euler",
   "source_url": "http://projecteuler.net/problem=4"

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -16,15 +16,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "palindrome-products.js"
-    ],
-    "test": [
-      "palindrome-products.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["palindrome-products.js"],
+    "test": ["palindrome-products.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Problem 4 at Project Euler",
   "source_url": "http://projecteuler.net/problem=4"

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -25,15 +25,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "palindrome-products.js"
-    ],
-    "test": [
-      "palindrome-products.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["palindrome-products.js"],
+    "test": ["palindrome-products.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Problem 4 at Project Euler",
   "source_url": "http://projecteuler.net/problem=4"

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -2,32 +2,29 @@
   "blurb": "Detect palindrome products in a given range.",
   "authors": [],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "cmccandless",
     "draalger",
     "ErikSchierboom",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "javaeeeee",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
     "smb26",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["palindrome-products.js"],
-    "test": ["palindrome-products.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "palindrome-products.js"
+    ],
+    "test": [
+      "palindrome-products.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Problem 4 at Project Euler",
   "source_url": "http://projecteuler.net/problem=4"

--- a/exercises/practice/palindrome-products/package.json
+++ b/exercises/practice/palindrome-products/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,10 +1,37 @@
 {
   "blurb": "Determine if a sentence is a pangram.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "amscotti",
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "PakkuDon",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tarunvelli",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["pangram.js"],
-    "test": ["pangram.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pangram.js"
+    ],
+    "test": [
+      "pangram.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Pangram"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Determine if a sentence is a pangram.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "amscotti",
     "ankorGH",
@@ -14,15 +12,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "pangram.js"
-    ],
-    "test": [
-      "pangram.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["pangram.js"],
+    "test": ["pangram.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Pangram"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,29 +1,28 @@
 {
   "blurb": "Determine if a sentence is a pangram.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "amscotti",
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "PakkuDon",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
     "tarunvelli",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["pangram.js"],
-    "test": ["pangram.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pangram.js"
+    ],
+    "test": [
+      "pangram.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Pangram"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Determine if a sentence is a pangram.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "amscotti",
     "andreasolund",
@@ -23,15 +21,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "pangram.js"
-    ],
-    "test": [
-      "pangram.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["pangram.js"],
+    "test": ["pangram.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Pangram"

--- a/exercises/practice/pangram/package.json
+++ b/exercises/practice/pangram/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "msomji",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["pascals-triangle.js"],
-    "test": ["pascals-triangle.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pascals-triangle.js"
+    ],
+    "test": [
+      "pascals-triangle.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Pascal's Triangle at Wolfram Math World",
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -21,15 +19,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "pascals-triangle.js"
-    ],
-    "test": [
-      "pascals-triangle.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["pascals-triangle.js"],
+    "test": ["pascals-triangle.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Pascal's Triangle at Wolfram Math World",
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,27 +1,26 @@
 {
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
     "msomji",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["pascals-triangle.js"],
-    "test": ["pascals-triangle.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pascals-triangle.js"
+    ],
+    "test": [
+      "pascals-triangle.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Pascal's Triangle at Wolfram Math World",
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -12,15 +10,9 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "pascals-triangle.js"
-    ],
-    "test": [
-      "pascals-triangle.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["pascals-triangle.js"],
+    "test": ["pascals-triangle.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Pascal's Triangle at Wolfram Math World",
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"

--- a/exercises/practice/pascals-triangle/package.json
+++ b/exercises/practice/pascals-triangle/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,25 +1,26 @@
 {
   "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
-  "authors": ["komyg"],
+  "authors": [
+    "komyg"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "serixscorpio",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["perfect-numbers.js"],
-    "test": ["perfect-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "perfect-numbers.js"
+    ],
+    "test": [
+      "perfect-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
   "source_url": "http://shop.oreilly.com/product/0636920029687.do"

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
-  "authors": [
-    "komyg"
-  ],
+  "authors": ["komyg"],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -12,15 +10,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "perfect-numbers.js"
-    ],
-    "test": [
-      "perfect-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["perfect-numbers.js"],
+    "test": ["perfect-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
   "source_url": "http://shop.oreilly.com/product/0636920029687.do"

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
-  "authors": [
-    "komyg"
-  ],
+  "authors": ["komyg"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -19,15 +17,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "perfect-numbers.js"
-    ],
-    "test": [
-      "perfect-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["perfect-numbers.js"],
+    "test": ["perfect-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
   "source_url": "http://shop.oreilly.com/product/0636920029687.do"

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,10 +1,33 @@
 {
   "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
-  "authors": [],
+  "authors": [
+    "komyg"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["perfect-numbers.js"],
-    "test": ["perfect-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "perfect-numbers.js"
+    ],
+    "test": [
+      "perfect-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
   "source_url": "http://shop.oreilly.com/product/0636920029687.do"

--- a/exercises/practice/perfect-numbers/package.json
+++ b/exercises/practice/perfect-numbers/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,10 +1,38 @@
 {
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "draalger",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "LyleCharlesScott",
+    "matthewmorgan",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "saylerb",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["phone-number.js"],
-    "test": ["phone-number.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "phone-number.js"
+    ],
+    "test": [
+      "phone-number.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Event Manager by JumpstartLab",
   "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -16,15 +14,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "phone-number.js"
-    ],
-    "test": [
-      "phone-number.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["phone-number.js"],
+    "test": ["phone-number.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Event Manager by JumpstartLab",
   "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -24,15 +22,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "phone-number.js"
-    ],
-    "test": [
-      "phone-number.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["phone-number.js"],
+    "test": ["phone-number.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Event Manager by JumpstartLab",
   "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,30 +1,30 @@
 {
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "draalger",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "LyleCharlesScott",
     "matthewmorgan",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "saylerb",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["phone-number.js"],
-    "test": ["phone-number.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "phone-number.js"
+    ],
+    "test": [
+      "phone-number.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Event Manager by JumpstartLab",
   "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"

--- a/exercises/practice/phone-number/package.json
+++ b/exercises/practice/phone-number/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,28 +1,27 @@
 {
   "blurb": "Implement a program that translates from English to Pig Latin",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "konni2020",
-    "lantran",
     "matthewmorgan",
     "ntshcalleia",
-    "paparomeo",
-    "PSalant726",
-    "rpottsoh",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["pig-latin.js"],
-    "test": ["pig-latin.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pig-latin.js"
+    ],
+    "test": [
+      "pig-latin.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement a program that translates from English to Pig Latin",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -22,15 +20,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "pig-latin.js"
-    ],
-    "test": [
-      "pig-latin.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["pig-latin.js"],
+    "test": ["pig-latin.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement a program that translates from English to Pig Latin",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "konni2020",
@@ -13,15 +11,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "pig-latin.js"
-    ],
-    "test": [
-      "pig-latin.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["pig-latin.js"],
+    "test": ["pig-latin.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Implement a program that translates from English to Pig Latin",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "konni2020",
+    "lantran",
+    "matthewmorgan",
+    "ntshcalleia",
+    "paparomeo",
+    "PSalant726",
+    "rpottsoh",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["pig-latin.js"],
-    "test": ["pig-latin.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pig-latin.js"
+    ],
+    "test": [
+      "pig-latin.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"

--- a/exercises/practice/pig-latin/package.json
+++ b/exercises/practice/pig-latin/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/point-mutations/.meta/config.json
+++ b/exercises/practice/point-mutations/.meta/config.json
@@ -1,10 +1,31 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "paparomeo",
+    "PSalant726",
+    "rpottsoh",
+    "SleeplessByte",
+    "tejasbubane",
+    "thanhcng",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["point-mutations.js"],
-    "test": ["point-mutations.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "point-mutations.js"
+    ],
+    "test": [
+      "point-mutations.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/point-mutations/.meta/config.json
+++ b/exercises/practice/point-mutations/.meta/config.json
@@ -1,24 +1,11 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": [
-    "matthewmorgan"
-  ],
-  "contributors": [
-    "ankorGH",
-    "SleeplessByte",
-    "tejasbubane",
-    "thanhcng"
-  ],
+  "authors": ["matthewmorgan"],
+  "contributors": ["ankorGH", "SleeplessByte", "tejasbubane", "thanhcng"],
   "files": {
-    "solution": [
-      "point-mutations.js"
-    ],
-    "test": [
-      "point-mutations.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["point-mutations.js"],
+    "test": ["point-mutations.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/point-mutations/.meta/config.json
+++ b/exercises/practice/point-mutations/.meta/config.json
@@ -1,23 +1,24 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "paparomeo",
-    "PSalant726",
-    "rpottsoh",
     "SleeplessByte",
     "tejasbubane",
-    "thanhcng",
-    "Tyresius92"
+    "thanhcng"
   ],
   "files": {
-    "solution": ["point-mutations.js"],
-    "test": ["point-mutations.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "point-mutations.js"
+    ],
+    "test": [
+      "point-mutations.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/point-mutations/.meta/config.json
+++ b/exercises/practice/point-mutations/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -17,15 +15,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "point-mutations.js"
-    ],
-    "test": [
-      "point-mutations.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["point-mutations.js"],
+    "test": ["point-mutations.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/point-mutations/package.json
+++ b/exercises/practice/point-mutations/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Compute the prime factors of a given natural number.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["prime-factors.js"],
-    "test": ["prime-factors.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "prime-factors.js"
+    ],
+    "test": [
+      "prime-factors.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Prime Factors Kata by Uncle Bob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Compute the prime factors of a given natural number.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -20,15 +18,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "prime-factors.js"
-    ],
-    "test": [
-      "prime-factors.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["prime-factors.js"],
+    "test": ["prime-factors.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Prime Factors Kata by Uncle Bob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Compute the prime factors of a given natural number.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -11,15 +9,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "prime-factors.js"
-    ],
-    "test": [
-      "prime-factors.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["prime-factors.js"],
+    "test": ["prime-factors.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Prime Factors Kata by Uncle Bob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,26 +1,25 @@
 {
   "blurb": "Compute the prime factors of a given natural number.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["prime-factors.js"],
-    "test": ["prime-factors.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "prime-factors.js"
+    ],
+    "test": [
+      "prime-factors.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Prime Factors Kata by Uncle Bob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"

--- a/exercises/practice/prime-factors/package.json
+++ b/exercises/practice/prime-factors/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,24 +1,11 @@
 {
   "blurb": "Translate RNA sequences into proteins.",
-  "authors": [
-    "RobinCsl"
-  ],
-  "contributors": [
-    "ankorGH",
-    "SleeplessByte",
-    "tejasbubane",
-    "WebCu"
-  ],
+  "authors": ["RobinCsl"],
+  "contributors": ["ankorGH", "SleeplessByte", "tejasbubane", "WebCu"],
   "files": {
-    "solution": [
-      "protein-translation.js"
-    ],
-    "test": [
-      "protein-translation.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["protein-translation.js"],
+    "test": ["protein-translation.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Tyler Long"
 }

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Translate RNA sequences into proteins.",
-  "authors": [
-    "RobinCsl"
-  ],
+  "authors": ["RobinCsl"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -19,15 +17,9 @@
     "WebCu"
   ],
   "files": {
-    "solution": [
-      "protein-translation.js"
-    ],
-    "test": [
-      "protein-translation.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["protein-translation.js"],
+    "test": ["protein-translation.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Tyler Long"
 }

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,10 +1,33 @@
 {
   "blurb": "Translate RNA sequences into proteins.",
-  "authors": [],
+  "authors": [
+    "RobinCsl"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "WebCu"
+  ],
   "files": {
-    "solution": ["protein-translation.js"],
-    "test": ["protein-translation.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "protein-translation.js"
+    ],
+    "test": [
+      "protein-translation.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Tyler Long"
 }

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,25 +1,24 @@
 {
   "blurb": "Translate RNA sequences into proteins.",
-  "authors": ["RobinCsl"],
+  "authors": [
+    "RobinCsl"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
-    "rchavarria",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "WebCu"
   ],
   "files": {
-    "solution": ["protein-translation.js"],
-    "test": ["protein-translation.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "protein-translation.js"
+    ],
+    "test": [
+      "protein-translation.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Tyler Long"
 }

--- a/exercises/practice/protein-translation/package.json
+++ b/exercises/practice/protein-translation/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
-  "authors": [
-    "skabbass1"
-  ],
+  "authors": ["skabbass1"],
   "contributors": [
     "ankorGH",
     "serixscorpio",
@@ -11,15 +9,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "proverb.js"
-    ],
-    "test": [
-      "proverb.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["proverb.js"],
+    "test": ["proverb.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/For_Want_of_a_Nail"

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,26 +1,25 @@
 {
   "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
-  "authors": ["skabbass1"],
+  "authors": [
+    "skabbass1"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
-    "rchavarria",
     "serixscorpio",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["proverb.js"],
-    "test": ["proverb.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "proverb.js"
+    ],
+    "test": [
+      "proverb.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/For_Want_of_a_Nail"

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
-  "authors": [],
+  "authors": [
+    "skabbass1"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["proverb.js"],
-    "test": ["proverb.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "proverb.js"
+    ],
+    "test": [
+      "proverb.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/For_Want_of_a_Nail"

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
-  "authors": [
-    "skabbass1"
-  ],
+  "authors": ["skabbass1"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -20,15 +18,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "proverb.js"
-    ],
-    "test": [
-      "proverb.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["proverb.js"],
+    "test": ["proverb.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/For_Want_of_a_Nail"

--- a/exercises/practice/proverb/package.json
+++ b/exercises/practice/proverb/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -12,15 +10,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "pythagorean-triplet.js"
-    ],
-    "test": [
-      "pythagorean-triplet.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["pythagorean-triplet.js"],
+    "test": ["pythagorean-triplet.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Problem 9 at Project Euler",
   "source_url": "http://projecteuler.net/problem=9"

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["pythagorean-triplet.js"],
-    "test": ["pythagorean-triplet.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pythagorean-triplet.js"
+    ],
+    "test": [
+      "pythagorean-triplet.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Problem 9 at Project Euler",
   "source_url": "http://projecteuler.net/problem=9"

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -20,15 +18,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "pythagorean-triplet.js"
-    ],
-    "test": [
-      "pythagorean-triplet.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["pythagorean-triplet.js"],
+    "test": ["pythagorean-triplet.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Problem 9 at Project Euler",
   "source_url": "http://projecteuler.net/problem=9"

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -1,26 +1,26 @@
 {
   "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["pythagorean-triplet.js"],
-    "test": ["pythagorean-triplet.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pythagorean-triplet.js"
+    ],
+    "test": [
+      "pythagorean-triplet.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Problem 9 at Project Euler",
   "source_url": "http://projecteuler.net/problem=9"

--- a/exercises/practice/pythagorean-triplet/package.json
+++ b/exercises/practice/pythagorean-triplet/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "abhnvgupta",
     "alexashley",
@@ -16,15 +14,9 @@
     "smb26"
   ],
   "files": {
-    "solution": [
-      "queen-attack.js"
-    ],
-    "test": [
-      "queen-attack.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["queen-attack.js"],
+    "test": ["queen-attack.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,10 +1,39 @@
 {
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "abhnvgupta",
+    "alexashley",
+    "andreasolund",
+    "BoDaly",
+    "ErikSchierboom",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "IndelicateArgot",
+    "javaeeeee",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "smb26",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["queen-attack.js"],
-    "test": ["queen-attack.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "queen-attack.js"
+    ],
+    "test": [
+      "queen-attack.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "abhnvgupta",
     "alexashley",
@@ -25,15 +23,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "queen-attack.js"
-    ],
-    "test": [
-      "queen-attack.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["queen-attack.js"],
+    "test": ["queen-attack.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,31 +1,30 @@
 {
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "abhnvgupta",
     "alexashley",
-    "andreasolund",
     "BoDaly",
     "ErikSchierboom",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "IndelicateArgot",
     "javaeeeee",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
-    "smb26",
-    "tejasbubane",
-    "Tyresius92"
+    "smb26"
   ],
   "files": {
-    "solution": ["queen-attack.js"],
-    "test": ["queen-attack.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "queen-attack.js"
+    ],
+    "test": [
+      "queen-attack.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/queen-attack/package.json
+++ b/exercises/practice/queen-attack/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -13,15 +11,9 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "raindrops.js"
-    ],
-    "test": [
-      "raindrops.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["raindrops.js"],
+    "test": ["raindrops.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,28 +1,27 @@
 {
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "cmccandless",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "JesseSingleton",
-    "lantran",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["raindrops.js"],
-    "test": ["raindrops.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "raindrops.js"
+    ],
+    "test": [
+      "raindrops.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "cmccandless",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "JesseSingleton",
+    "lantran",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["raindrops.js"],
-    "test": ["raindrops.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "raindrops.js"
+    ],
+    "test": [
+      "raindrops.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -22,15 +20,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "raindrops.js"
-    ],
-    "test": [
-      "raindrops.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["raindrops.js"],
+    "test": ["raindrops.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"

--- a/exercises/practice/raindrops/package.json
+++ b/exercises/practice/raindrops/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -1,10 +1,30 @@
 {
   "blurb": "Implement rational numbers.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "paparomeo",
+    "PSalant726",
+    "rpottsoh",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["rational-numbers.js"],
-    "test": ["rational-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rational-numbers.js"
+    ],
+    "test": [
+      "rational-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Rational_number"

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -1,22 +1,23 @@
 {
   "blurb": "Implement rational numbers.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "paparomeo",
-    "PSalant726",
-    "rpottsoh",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["rational-numbers.js"],
-    "test": ["rational-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rational-numbers.js"
+    ],
+    "test": [
+      "rational-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Rational_number"

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement rational numbers.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -16,15 +14,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "rational-numbers.js"
-    ],
-    "test": [
-      "rational-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["rational-numbers.js"],
+    "test": ["rational-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Rational_number"

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -1,23 +1,11 @@
 {
   "blurb": "Implement rational numbers.",
-  "authors": [
-    "matthewmorgan"
-  ],
-  "contributors": [
-    "ankorGH",
-    "SleeplessByte",
-    "tejasbubane"
-  ],
+  "authors": ["matthewmorgan"],
+  "contributors": ["ankorGH", "SleeplessByte", "tejasbubane"],
   "files": {
-    "solution": [
-      "rational-numbers.js"
-    ],
-    "test": [
-      "rational-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["rational-numbers.js"],
+    "test": ["rational-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Rational_number"

--- a/exercises/practice/rational-numbers/package.json
+++ b/exercises/practice/rational-numbers/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -1,9 +1,31 @@
 {
   "blurb": "Implement a basic reactive system.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "Boto1",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "joshgoebel",
+    "PakkuDon",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["react.js"],
-    "test": ["react.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "react.js"
+    ],
+    "test": [
+      "react.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -1,23 +1,24 @@
 {
   "blurb": "Implement a basic reactive system.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "Boto1",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "joshgoebel",
     "PakkuDon",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["react.js"],
-    "test": ["react.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "react.js"
+    ],
+    "test": [
+      "react.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement a basic reactive system.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "Boto1",
     "G-Rath",
@@ -18,14 +16,8 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "react.js"
-    ],
-    "test": [
-      "react.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["react.js"],
+    "test": ["react.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement a basic reactive system.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "Boto1",
     "joshgoebel",
@@ -11,14 +9,8 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "react.js"
-    ],
-    "test": [
-      "react.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["react.js"],
+    "test": ["react.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/react/package.json
+++ b/exercises/practice/react/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Count the rectangles in an ASCII diagram.",
-  "authors": [
-    "MattH-be"
-  ],
+  "authors": ["MattH-be"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -18,14 +16,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "rectangles.js"
-    ],
-    "test": [
-      "rectangles.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["rectangles.js"],
+    "test": ["rectangles.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -1,9 +1,31 @@
 {
   "blurb": "Count the rectangles in an ASCII diagram.",
-  "authors": [],
+  "authors": [
+    "MattH-be"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["rectangles.js"],
-    "test": ["rectangles.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rectangles.js"
+    ],
+    "test": [
+      "rectangles.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -1,23 +1,23 @@
 {
   "blurb": "Count the rectangles in an ASCII diagram.",
-  "authors": ["MattH-be"],
+  "authors": [
+    "MattH-be"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
-    "rchavarria",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["rectangles.js"],
-    "test": ["rectangles.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rectangles.js"
+    ],
+    "test": [
+      "rectangles.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -1,23 +1,10 @@
 {
   "blurb": "Count the rectangles in an ASCII diagram.",
-  "authors": [
-    "MattH-be"
-  ],
-  "contributors": [
-    "ankorGH",
-    "SleeplessByte",
-    "tejasbubane",
-    "xarxziux"
-  ],
+  "authors": ["MattH-be"],
+  "contributors": ["ankorGH", "SleeplessByte", "tejasbubane", "xarxziux"],
   "files": {
-    "solution": [
-      "rectangles.js"
-    ],
-    "test": [
-      "rectangles.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["rectangles.js"],
+    "test": ["rectangles.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/rectangles/package.json
+++ b/exercises/practice/rectangles/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,23 +1,11 @@
 {
   "blurb": "Convert color codes, as used on resistors, to a numeric value.",
-  "authors": [
-    "tejasbubane"
-  ],
-  "contributors": [
-    "ankorGH",
-    "clockelliptic",
-    "SleeplessByte"
-  ],
+  "authors": ["tejasbubane"],
+  "contributors": ["ankorGH", "clockelliptic", "SleeplessByte"],
   "files": {
-    "solution": [
-      "resistor-color-duo.js"
-    ],
-    "test": [
-      "resistor-color-duo.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["resistor-color-duo.js"],
+    "test": ["resistor-color-duo.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1464"

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert color codes, as used on resistors, to a numeric value.",
-  "authors": [
-    "tejasbubane"
-  ],
+  "authors": ["tejasbubane"],
   "contributors": [
     "ankorGH",
     "clockelliptic",
@@ -12,15 +10,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "resistor-color-duo.js"
-    ],
-    "test": [
-      "resistor-color-duo.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["resistor-color-duo.js"],
+    "test": ["resistor-color-duo.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1464"

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,18 +1,23 @@
 {
   "blurb": "Convert color codes, as used on resistors, to a numeric value.",
-  "authors": ["tejasbubane"],
+  "authors": [
+    "tejasbubane"
+  ],
   "contributors": [
     "ankorGH",
     "clockelliptic",
-    "G-Rath",
-    "paparomeo",
-    "SleeplessByte",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["resistor-color-duo.js"],
-    "test": ["resistor-color-duo.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "resistor-color-duo.js"
+    ],
+    "test": [
+      "resistor-color-duo.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1464"

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,10 +1,26 @@
 {
   "blurb": "Convert color codes, as used on resistors, to a numeric value.",
-  "authors": [],
+  "authors": [
+    "tejasbubane"
+  ],
+  "contributors": [
+    "ankorGH",
+    "clockelliptic",
+    "G-Rath",
+    "paparomeo",
+    "SleeplessByte",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["resistor-color-duo.js"],
-    "test": ["resistor-color-duo.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "resistor-color-duo.js"
+    ],
+    "test": [
+      "resistor-color-duo.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1464"

--- a/exercises/practice/resistor-color-duo/package.json
+++ b/exercises/practice/resistor-color-duo/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -1,23 +1,11 @@
 {
   "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
-  "authors": [
-    "SleeplessByte"
-  ],
-  "contributors": [
-    "hayashi-ay",
-    "paparomeo",
-    "tejasbubane"
-  ],
+  "authors": ["SleeplessByte"],
+  "contributors": ["hayashi-ay", "paparomeo", "tejasbubane"],
   "files": {
-    "solution": [
-      "resistor-color-trio.js"
-    ],
-    "test": [
-      "resistor-color-trio.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["resistor-color-trio.js"],
+    "test": ["resistor-color-trio.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1549"

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -1,11 +1,21 @@
 {
   "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
-  "authors": ["SleeplessByte"],
-  "contributors": ["hayashi-ay", "paparomeo", "tejasbubane"],
+  "authors": [
+    "SleeplessByte"
+  ],
+  "contributors": [
+    "hayashi-ay"
+  ],
   "files": {
-    "solution": ["resistor-color-trio.js"],
-    "test": ["resistor-color-trio.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "resistor-color-trio.js"
+    ],
+    "test": [
+      "resistor-color-trio.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1549"

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -1,10 +1,23 @@
 {
   "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
-  "authors": [],
+  "authors": [
+    "SleeplessByte"
+  ],
+  "contributors": [
+    "hayashi-ay",
+    "paparomeo",
+    "tejasbubane"
+  ],
   "files": {
-    "solution": ["resistor-color-trio.js"],
-    "test": ["resistor-color-trio.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "resistor-color-trio.js"
+    ],
+    "test": [
+      "resistor-color-trio.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1549"

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
-  "authors": [
-    "SleeplessByte"
-  ],
-  "contributors": [
-    "hayashi-ay"
-  ],
+  "authors": ["SleeplessByte"],
+  "contributors": ["hayashi-ay"],
   "files": {
-    "solution": [
-      "resistor-color-trio.js"
-    ],
-    "test": [
-      "resistor-color-trio.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["resistor-color-trio.js"],
+    "test": ["resistor-color-trio.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1549"

--- a/exercises/practice/resistor-color-trio/package.json
+++ b/exercises/practice/resistor-color-trio/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,18 +1,22 @@
 {
   "blurb": "Convert a resistor band's color to its numeric representation",
-  "authors": ["SleeplessByte"],
+  "authors": [
+    "SleeplessByte"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "paparomeo",
-    "tejasbubane",
-    "TomPradat",
-    "Tyresius92"
+    "TomPradat"
   ],
   "files": {
-    "solution": ["resistor-color.js"],
-    "test": ["resistor-color.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "resistor-color.js"
+    ],
+    "test": [
+      "resistor-color.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458"

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,10 +1,26 @@
 {
   "blurb": "Convert a resistor band's color to its numeric representation",
-  "authors": [],
+  "authors": [
+    "SleeplessByte"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "paparomeo",
+    "tejasbubane",
+    "TomPradat",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["resistor-color.js"],
-    "test": ["resistor-color.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "resistor-color.js"
+    ],
+    "test": [
+      "resistor-color.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458"

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,22 +1,11 @@
 {
   "blurb": "Convert a resistor band's color to its numeric representation",
-  "authors": [
-    "SleeplessByte"
-  ],
-  "contributors": [
-    "ankorGH",
-    "TomPradat"
-  ],
+  "authors": ["SleeplessByte"],
+  "contributors": ["ankorGH", "TomPradat"],
   "files": {
-    "solution": [
-      "resistor-color.js"
-    ],
-    "test": [
-      "resistor-color.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["resistor-color.js"],
+    "test": ["resistor-color.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458"

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a resistor band's color to its numeric representation",
-  "authors": [
-    "SleeplessByte"
-  ],
+  "authors": ["SleeplessByte"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -12,15 +10,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "resistor-color.js"
-    ],
-    "test": [
-      "resistor-color.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["resistor-color.js"],
+    "test": ["resistor-color.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458"

--- a/exercises/practice/resistor-color/package.json
+++ b/exercises/practice/resistor-color/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,24 +1,11 @@
 {
   "blurb": "Reverse a string",
-  "authors": [
-    "gavinhenderson"
-  ],
-  "contributors": [
-    "ankorGH",
-    "d-vail",
-    "ovidiu141",
-    "SleeplessByte"
-  ],
+  "authors": ["gavinhenderson"],
+  "contributors": ["ankorGH", "d-vail", "ovidiu141", "SleeplessByte"],
   "files": {
-    "solution": [
-      "reverse-string.js"
-    ],
-    "test": [
-      "reverse-string.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["reverse-string.js"],
+    "test": ["reverse-string.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Introductory challenge to reverse an input string",
   "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Reverse a string",
-  "authors": [
-    "gavinhenderson"
-  ],
+  "authors": ["gavinhenderson"],
   "contributors": [
     "ankorGH",
     "d-vail",
@@ -18,15 +16,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "reverse-string.js"
-    ],
-    "test": [
-      "reverse-string.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["reverse-string.js"],
+    "test": ["reverse-string.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Introductory challenge to reverse an input string",
   "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,24 +1,24 @@
 {
   "blurb": "Reverse a string",
-  "authors": ["gavinhenderson"],
+  "authors": [
+    "gavinhenderson"
+  ],
   "contributors": [
     "ankorGH",
     "d-vail",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
-    "rpottsoh",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["reverse-string.js"],
-    "test": ["reverse-string.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "reverse-string.js"
+    ],
+    "test": [
+      "reverse-string.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Introductory challenge to reverse an input string",
   "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,10 +1,32 @@
 {
   "blurb": "Reverse a string",
-  "authors": [],
+  "authors": [
+    "gavinhenderson"
+  ],
+  "contributors": [
+    "ankorGH",
+    "d-vail",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rpottsoh",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["reverse-string.js"],
-    "test": ["reverse-string.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "reverse-string.js"
+    ],
+    "test": [
+      "reverse-string.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Introductory challenge to reverse an input string",
   "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"

--- a/exercises/practice/reverse-string/package.json
+++ b/exercises/practice/reverse-string/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "amscotti",
     "ankorGH",
@@ -16,15 +14,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "rna-transcription.js"
-    ],
-    "test": [
-      "rna-transcription.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["rna-transcription.js"],
+    "test": ["rna-transcription.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,10 +1,38 @@
 {
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "amscotti",
+    "andreasolund",
+    "ankorGH",
+    "draalger",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tarunvelli",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["rna-transcription.js"],
-    "test": ["rna-transcription.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rna-transcription.js"
+    ],
+    "test": [
+      "rna-transcription.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "amscotti",
     "andreasolund",
@@ -24,15 +22,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "rna-transcription.js"
-    ],
-    "test": [
-      "rna-transcription.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["rna-transcription.js"],
+    "test": ["rna-transcription.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,30 +1,30 @@
 {
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "amscotti",
-    "andreasolund",
     "ankorGH",
     "draalger",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
     "tarunvelli",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["rna-transcription.js"],
-    "test": ["rna-transcription.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rna-transcription.js"
+    ],
+    "test": [
+      "rna-transcription.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"

--- a/exercises/practice/rna-transcription/package.json
+++ b/exercises/practice/rna-transcription/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Manage robot factory settings.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "draalger",
     "kytrinyx",
@@ -13,15 +11,9 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "robot-name.js"
-    ],
-    "test": [
-      "robot-name.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["robot-name.js"],
+    "test": ["robot-name.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A debugging session with Paul Blackwell at gSchool."
 }

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Manage robot factory settings.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "draalger",
@@ -22,15 +20,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "robot-name.js"
-    ],
-    "test": [
-      "robot-name.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["robot-name.js"],
+    "test": ["robot-name.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A debugging session with Paul Blackwell at gSchool."
 }

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Manage robot factory settings.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "draalger",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "masters3d",
+    "matthewmorgan",
+    "ntshcalleia",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["robot-name.js"],
-    "test": ["robot-name.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "robot-name.js"
+    ],
+    "test": [
+      "robot-name.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A debugging session with Paul Blackwell at gSchool."
 }

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,28 +1,27 @@
 {
   "blurb": "Manage robot factory settings.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "draalger",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "masters3d",
     "matthewmorgan",
     "ntshcalleia",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["robot-name.js"],
-    "test": ["robot-name.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "robot-name.js"
+    ],
+    "test": [
+      "robot-name.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A debugging session with Paul Blackwell at gSchool."
 }

--- a/exercises/practice/robot-name/package.json
+++ b/exercises/practice/robot-name/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,27 +1,27 @@
 {
   "blurb": "Write a robot simulator.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "jscheffner",
-    "lantran",
     "matthewmorgan",
     "ntshcalleia",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["robot-simulator.js"],
-    "test": ["robot-simulator.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "robot-simulator.js"
+    ],
+    "test": [
+      "robot-simulator.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by an interview question at a famous company.",
   "source_url": ""

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Write a robot simulator.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "jscheffner",
@@ -13,15 +11,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "robot-simulator.js"
-    ],
-    "test": [
-      "robot-simulator.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["robot-simulator.js"],
+    "test": ["robot-simulator.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by an interview question at a famous company.",
   "source_url": ""

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Write a robot simulator.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -21,15 +19,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "robot-simulator.js"
-    ],
-    "test": [
-      "robot-simulator.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["robot-simulator.js"],
+    "test": ["robot-simulator.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by an interview question at a famous company.",
   "source_url": ""

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Write a robot simulator.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "jscheffner",
+    "lantran",
+    "matthewmorgan",
+    "ntshcalleia",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["robot-simulator.js"],
-    "test": ["robot-simulator.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "robot-simulator.js"
+    ],
+    "test": [
+      "robot-simulator.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by an interview question at a famous company.",
   "source_url": ""

--- a/exercises/practice/robot-simulator/package.json
+++ b/exercises/practice/robot-simulator/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,27 +1,26 @@
 {
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "cmccandless",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "serixscorpio",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["roman-numerals.js"],
-    "test": ["roman-numerals.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "roman-numerals.js"
+    ],
+    "test": [
+      "roman-numerals.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Roman Numeral Kata",
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -21,15 +19,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "roman-numerals.js"
-    ],
-    "test": [
-      "roman-numerals.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["roman-numerals.js"],
+    "test": ["roman-numerals.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Roman Numeral Kata",
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -12,15 +10,9 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "roman-numerals.js"
-    ],
-    "test": [
-      "roman-numerals.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["roman-numerals.js"],
+    "test": ["roman-numerals.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Roman Numeral Kata",
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "cmccandless",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["roman-numerals.js"],
-    "test": ["roman-numerals.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "roman-numerals.js"
+    ],
+    "test": [
+      "roman-numerals.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Roman Numeral Kata",
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"

--- a/exercises/practice/roman-numerals/package.json
+++ b/exercises/practice/roman-numerals/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -1,10 +1,32 @@
 {
   "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
-  "authors": [],
+  "authors": [
+    "MattH-be"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["rotational-cipher.js"],
-    "test": ["rotational-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rotational-cipher.js"
+    ],
+    "test": [
+      "rotational-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Caesar_cipher"

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -1,24 +1,24 @@
 {
   "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
-  "authors": ["MattH-be"],
+  "authors": [
+    "MattH-be"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
-    "rchavarria",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["rotational-cipher.js"],
-    "test": ["rotational-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rotational-cipher.js"
+    ],
+    "test": [
+      "rotational-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Caesar_cipher"

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -1,24 +1,11 @@
 {
   "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
-  "authors": [
-    "MattH-be"
-  ],
-  "contributors": [
-    "ankorGH",
-    "SleeplessByte",
-    "tejasbubane",
-    "xarxziux"
-  ],
+  "authors": ["MattH-be"],
+  "contributors": ["ankorGH", "SleeplessByte", "tejasbubane", "xarxziux"],
   "files": {
-    "solution": [
-      "rotational-cipher.js"
-    ],
-    "test": [
-      "rotational-cipher.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["rotational-cipher.js"],
+    "test": ["rotational-cipher.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Caesar_cipher"

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
-  "authors": [
-    "MattH-be"
-  ],
+  "authors": ["MattH-be"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -18,15 +16,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "rotational-cipher.js"
-    ],
-    "test": [
-      "rotational-cipher.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["rotational-cipher.js"],
+    "test": ["rotational-cipher.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Caesar_cipher"

--- a/exercises/practice/rotational-cipher/package.json
+++ b/exercises/practice/rotational-cipher/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement run-length encoding and decoding.",
-  "authors": [
-    "skabbass1"
-  ],
+  "authors": ["skabbass1"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -19,15 +17,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "run-length-encoding.js"
-    ],
-    "test": [
-      "run-length-encoding.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["run-length-encoding.js"],
+    "test": ["run-length-encoding.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding"

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,10 +1,33 @@
 {
   "blurb": "Implement run-length encoding and decoding.",
-  "authors": [],
+  "authors": [
+    "skabbass1"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["run-length-encoding.js"],
-    "test": ["run-length-encoding.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "run-length-encoding.js"
+    ],
+    "test": [
+      "run-length-encoding.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding"

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,25 +1,23 @@
 {
   "blurb": "Implement run-length encoding and decoding.",
-  "authors": ["skabbass1"],
+  "authors": [
+    "skabbass1"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
-    "rchavarria",
     "serixscorpio",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["run-length-encoding.js"],
-    "test": ["run-length-encoding.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "run-length-encoding.js"
+    ],
+    "test": [
+      "run-length-encoding.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding"

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,23 +1,11 @@
 {
   "blurb": "Implement run-length encoding and decoding.",
-  "authors": [
-    "skabbass1"
-  ],
-  "contributors": [
-    "ankorGH",
-    "serixscorpio",
-    "SleeplessByte"
-  ],
+  "authors": ["skabbass1"],
+  "contributors": ["ankorGH", "serixscorpio", "SleeplessByte"],
   "files": {
-    "solution": [
-      "run-length-encoding.js"
-    ],
-    "test": [
-      "run-length-encoding.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["run-length-encoding.js"],
+    "test": ["run-length-encoding.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding"

--- a/exercises/practice/run-length-encoding/package.json
+++ b/exercises/practice/run-length-encoding/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -1,27 +1,26 @@
 {
   "blurb": "Detect saddle points in a matrix.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
-    "rpottsoh",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["saddle-points.js"],
-    "test": ["saddle-points.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "saddle-points.js"
+    ],
+    "test": [
+      "saddle-points.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Detect saddle points in a matrix.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "rpottsoh",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["saddle-points.js"],
-    "test": ["saddle-points.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "saddle-points.js"
+    ],
+    "test": [
+      "saddle-points.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Detect saddle points in a matrix.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -21,15 +19,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "saddle-points.js"
-    ],
-    "test": [
-      "saddle-points.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["saddle-points.js"],
+    "test": ["saddle-points.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Detect saddle points in a matrix.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "ovidiu141",
@@ -12,15 +10,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "saddle-points.js"
-    ],
-    "test": [
-      "saddle-points.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["saddle-points.js"],
+    "test": ["saddle-points.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/saddle-points/package.json
+++ b/exercises/practice/saddle-points/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "msomji",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "rpottsoh",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["say.js"],
-    "test": ["say.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "say.js"
+    ],
+    "test": [
+      "say.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on JavaRanch CattleDrive, exercise 4a",
   "source_url": "http://www.javaranch.com/say.jsp"

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,27 +1,26 @@
 {
   "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "msomji",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
-    "rpottsoh",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["say.js"],
-    "test": ["say.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "say.js"
+    ],
+    "test": [
+      "say.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on JavaRanch CattleDrive, exercise 4a",
   "source_url": "http://www.javaranch.com/say.jsp"

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -21,15 +19,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "say.js"
-    ],
-    "test": [
-      "say.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["say.js"],
+    "test": ["say.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on JavaRanch CattleDrive, exercise 4a",
   "source_url": "http://www.javaranch.com/say.jsp"

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "msomji",
@@ -12,15 +10,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "say.js"
-    ],
-    "test": [
-      "say.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["say.js"],
+    "test": ["say.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on JavaRanch CattleDrive, exercise 4a",
   "source_url": "http://www.javaranch.com/say.jsp"

--- a/exercises/practice/say/package.json
+++ b/exercises/practice/say/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -1,10 +1,20 @@
 {
   "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
-  "authors": ["seeksort"],
-  "contributors": ["paparomeo", "SleeplessByte", "tejasbubane"],
+  "authors": [
+    "seeksort"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["scale-generator.js"],
-    "test": ["scale-generator.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "scale-generator.js"
+    ],
+    "test": [
+      "scale-generator.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -1,9 +1,22 @@
 {
   "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
-  "authors": [],
+  "authors": [
+    "seeksort"
+  ],
+  "contributors": [
+    "paparomeo",
+    "SleeplessByte",
+    "tejasbubane"
+  ],
   "files": {
-    "solution": ["scale-generator.js"],
-    "test": ["scale-generator.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "scale-generator.js"
+    ],
+    "test": [
+      "scale-generator.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -1,20 +1,10 @@
 {
   "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
-  "authors": [
-    "seeksort"
-  ],
-  "contributors": [
-    "SleeplessByte"
-  ],
+  "authors": ["seeksort"],
+  "contributors": ["SleeplessByte"],
   "files": {
-    "solution": [
-      "scale-generator.js"
-    ],
-    "test": [
-      "scale-generator.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["scale-generator.js"],
+    "test": ["scale-generator.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -1,22 +1,10 @@
 {
   "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
-  "authors": [
-    "seeksort"
-  ],
-  "contributors": [
-    "paparomeo",
-    "SleeplessByte",
-    "tejasbubane"
-  ],
+  "authors": ["seeksort"],
+  "contributors": ["paparomeo", "SleeplessByte", "tejasbubane"],
   "files": {
-    "solution": [
-      "scale-generator.js"
-    ],
-    "test": [
-      "scale-generator.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["scale-generator.js"],
+    "test": ["scale-generator.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/scale-generator/package.json
+++ b/exercises/practice/scale-generator/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,28 +1,27 @@
 {
   "blurb": "Given a word, compute the Scrabble score for that word.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "amscotti",
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "ntshcalleia",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "serixscorpio",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["scrabble-score.js"],
-    "test": ["scrabble-score.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "scrabble-score.js"
+    ],
+    "test": [
+      "scrabble-score.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a word, compute the Scrabble score for that word.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "amscotti",
     "andreasolund",
@@ -22,15 +20,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "scrabble-score.js"
-    ],
-    "test": [
-      "scrabble-score.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["scrabble-score.js"],
+    "test": ["scrabble-score.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Given a word, compute the Scrabble score for that word.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "amscotti",
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "ntshcalleia",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["scrabble-score.js"],
-    "test": ["scrabble-score.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "scrabble-score.js"
+    ],
+    "test": [
+      "scrabble-score.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a word, compute the Scrabble score for that word.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "amscotti",
     "ankorGH",
@@ -13,15 +11,9 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "scrabble-score.js"
-    ],
-    "test": [
-      "scrabble-score.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["scrabble-score.js"],
+    "test": ["scrabble-score.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/scrabble-score/package.json
+++ b/exercises/practice/scrabble-score/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -21,15 +19,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "secret-handshake.js"
-    ],
-    "test": [
-      "secret-handshake.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["secret-handshake.js"],
+    "test": ["secret-handshake.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Bert, in Mary Poppins",
   "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,27 +1,27 @@
 {
   "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "ovidiu141",
-    "paparomeo",
     "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["secret-handshake.js"],
-    "test": ["secret-handshake.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "secret-handshake.js"
+    ],
+    "test": [
+      "secret-handshake.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Bert, in Mary Poppins",
   "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "ovidiu141",
@@ -13,15 +11,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "secret-handshake.js"
-    ],
-    "test": [
-      "secret-handshake.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["secret-handshake.js"],
+    "test": ["secret-handshake.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Bert, in Mary Poppins",
   "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["secret-handshake.js"],
-    "test": ["secret-handshake.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "secret-handshake.js"
+    ],
+    "test": [
+      "secret-handshake.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Bert, in Mary Poppins",
   "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"

--- a/exercises/practice/secret-handshake/package.json
+++ b/exercises/practice/secret-handshake/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "rpottsoh",
+    "ryanplusplus",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["series.js"],
-    "test": ["series.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "series.js"
+    ],
+    "test": [
+      "series.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A subset of the Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -13,15 +11,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "series.js"
-    ],
-    "test": [
-      "series.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["series.js"],
+    "test": ["series.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A subset of the Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -22,15 +20,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "series.js"
-    ],
-    "test": [
-      "series.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["series.js"],
+    "test": ["series.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A subset of the Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,28 +1,27 @@
 {
   "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
-    "rpottsoh",
     "ryanplusplus",
     "serixscorpio",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["series.js"],
-    "test": ["series.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "series.js"
+    ],
+    "test": [
+      "series.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A subset of the Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/series/package.json
+++ b/exercises/practice/series/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,10 +1,37 @@
 {
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "ntshcalleia",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "rpottsoh",
+    "ryanplusplus",
+    "SleeplessByte",
+    "smb26",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["sieve.js"],
-    "test": ["sieve.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "sieve.js"
+    ],
+    "test": [
+      "sieve.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Sieve of Eratosthenes at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "ntshcalleia",
@@ -13,15 +11,9 @@
     "smb26"
   ],
   "files": {
-    "solution": [
-      "sieve.js"
-    ],
-    "test": [
-      "sieve.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["sieve.js"],
+    "test": ["sieve.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Sieve of Eratosthenes at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,29 +1,27 @@
 {
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "ntshcalleia",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
-    "rpottsoh",
     "ryanplusplus",
     "SleeplessByte",
-    "smb26",
-    "tejasbubane",
-    "Tyresius92"
+    "smb26"
   ],
   "files": {
-    "solution": ["sieve.js"],
-    "test": ["sieve.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "sieve.js"
+    ],
+    "test": [
+      "sieve.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Sieve of Eratosthenes at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -23,15 +21,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "sieve.js"
-    ],
-    "test": [
-      "sieve.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["sieve.js"],
+    "test": ["sieve.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Sieve of Eratosthenes at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"

--- a/exercises/practice/sieve/package.json
+++ b/exercises/practice/sieve/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -1,34 +1,34 @@
 {
   "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "daveyarwood",
-    "G-Rath",
-    "gargrave",
     "hayashi-ay",
-    "iagocavalcante",
-    "lantran",
     "marocchino",
     "nicholejeannine",
     "paparomeo",
     "pawamoy",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "serixscorpio",
     "SleeplessByte",
-    "tejasbubane",
     "tekerson",
-    "Tyresius92",
     "Vankog",
     "xarxziux"
   ],
   "files": {
-    "solution": ["simple-cipher.js"],
-    "test": ["simple-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "simple-cipher.js"
+    ],
+    "test": [
+      "simple-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Substitution Cipher at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Substitution_cipher"

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "daveyarwood",
@@ -20,15 +18,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "simple-cipher.js"
-    ],
-    "test": [
-      "simple-cipher.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["simple-cipher.js"],
+    "test": ["simple-cipher.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Substitution Cipher at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Substitution_cipher"

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -28,15 +26,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "simple-cipher.js"
-    ],
-    "test": [
-      "simple-cipher.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["simple-cipher.js"],
+    "test": ["simple-cipher.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Substitution Cipher at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Substitution_cipher"

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -1,10 +1,42 @@
 {
   "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "daveyarwood",
+    "G-Rath",
+    "gargrave",
+    "hayashi-ay",
+    "iagocavalcante",
+    "lantran",
+    "marocchino",
+    "nicholejeannine",
+    "paparomeo",
+    "pawamoy",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "tekerson",
+    "Tyresius92",
+    "Vankog",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["simple-cipher.js"],
-    "test": ["simple-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "simple-cipher.js"
+    ],
+    "test": [
+      "simple-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Substitution Cipher at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Substitution_cipher"

--- a/exercises/practice/simple-cipher/package.json
+++ b/exercises/practice/simple-cipher/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -1,24 +1,24 @@
 {
   "blurb": "Write a simple linked list implementation that uses Elements and a List",
-  "authors": ["apapirovski"],
+  "authors": [
+    "apapirovski"
+  ],
   "contributors": [
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "maruthimohan",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["simple-linked-list.js"],
-    "test": ["simple-linked-list.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "simple-linked-list.js"
+    ],
+    "test": [
+      "simple-linked-list.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists.",
   "source_url": "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Write a simple linked list implementation that uses Elements and a List",
-  "authors": [
-    "apapirovski"
-  ],
+  "authors": ["apapirovski"],
   "contributors": [
     "G-Rath",
     "gargrave",
@@ -18,15 +16,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "simple-linked-list.js"
-    ],
-    "test": [
-      "simple-linked-list.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["simple-linked-list.js"],
+    "test": ["simple-linked-list.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists.",
   "source_url": "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -1,10 +1,32 @@
 {
   "blurb": "Write a simple linked list implementation that uses Elements and a List",
-  "authors": [],
+  "authors": [
+    "apapirovski"
+  ],
+  "contributors": [
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "maruthimohan",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["simple-linked-list.js"],
-    "test": ["simple-linked-list.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "simple-linked-list.js"
+    ],
+    "test": [
+      "simple-linked-list.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists.",
   "source_url": "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Write a simple linked list implementation that uses Elements and a List",
-  "authors": [
-    "apapirovski"
-  ],
+  "authors": ["apapirovski"],
   "contributors": [
     "maruthimohan",
     "matthewmorgan",
@@ -10,15 +8,9 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "simple-linked-list.js"
-    ],
-    "test": [
-      "simple-linked-list.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["simple-linked-list.js"],
+    "test": ["simple-linked-list.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists.",
   "source_url": "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"

--- a/exercises/practice/simple-linked-list/package.json
+++ b/exercises/practice/simple-linked-list/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,33 +1,32 @@
 {
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "cmccandless",
     "draalger",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "JesseSingleton",
-    "joshgoebel",
     "jscheffner",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
     "tarunvelli",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["space-age.js"],
-    "test": ["space-age.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "space-age.js"
+    ],
+    "test": [
+      "space-age.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,10 +1,41 @@
 {
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "cmccandless",
+    "draalger",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "JesseSingleton",
+    "joshgoebel",
+    "jscheffner",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tarunvelli",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["space-age.js"],
-    "test": ["space-age.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "space-age.js"
+    ],
+    "test": [
+      "space-age.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -27,15 +25,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "space-age.js"
-    ],
-    "test": [
-      "space-age.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["space-age.js"],
+    "test": ["space-age.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -18,15 +16,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "space-age.js"
-    ],
-    "test": [
-      "space-age.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["space-age.js"],
+    "test": ["space-age.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"

--- a/exercises/practice/space-age/package.json
+++ b/exercises/practice/space-age/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -1,10 +1,32 @@
 {
   "blurb": " Given the size, return a square matrix of numbers in spiral order.",
-  "authors": [],
+  "authors": [
+    "MattH-be"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["spiral-matrix.js"],
-    "test": ["spiral-matrix.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "spiral-matrix.js"
+    ],
+    "test": [
+      "spiral-matrix.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension.",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": " Given the size, return a square matrix of numbers in spiral order.",
-  "authors": [
-    "MattH-be"
-  ],
+  "authors": ["MattH-be"],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -11,15 +9,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "spiral-matrix.js"
-    ],
-    "test": [
-      "spiral-matrix.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["spiral-matrix.js"],
+    "test": ["spiral-matrix.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension.",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": " Given the size, return a square matrix of numbers in spiral order.",
-  "authors": [
-    "MattH-be"
-  ],
+  "authors": ["MattH-be"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -18,15 +16,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "spiral-matrix.js"
-    ],
-    "test": [
-      "spiral-matrix.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["spiral-matrix.js"],
+    "test": ["spiral-matrix.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension.",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -1,24 +1,25 @@
 {
   "blurb": " Given the size, return a square matrix of numbers in spiral order.",
-  "authors": ["MattH-be"],
+  "authors": [
+    "MattH-be"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["spiral-matrix.js"],
-    "test": ["spiral-matrix.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "spiral-matrix.js"
+    ],
+    "test": [
+      "spiral-matrix.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension.",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"

--- a/exercises/practice/spiral-matrix/package.json
+++ b/exercises/practice/spiral-matrix/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/square-root/.meta/config.json
+++ b/exercises/practice/square-root/.meta/config.json
@@ -1,22 +1,11 @@
 {
   "blurb": "Given a natural radicand, return its square root.",
-  "authors": [
-    "evelynstender"
-  ],
-  "contributors": [
-    "SleeplessByte",
-    "zimmah"
-  ],
+  "authors": ["evelynstender"],
+  "contributors": ["SleeplessByte", "zimmah"],
   "files": {
-    "solution": [
-      "square-root.js"
-    ],
-    "test": [
-      "square-root.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["square-root.js"],
+    "test": ["square-root.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "wolf99",
   "source_url": "https://github.com/exercism/problem-specifications/pull/1582"

--- a/exercises/practice/square-root/.meta/config.json
+++ b/exercises/practice/square-root/.meta/config.json
@@ -1,10 +1,22 @@
 {
   "blurb": "Given a natural radicand, return its square root.",
-  "authors": [],
+  "authors": [
+    "evelynstender"
+  ],
+  "contributors": [
+    "SleeplessByte",
+    "zimmah"
+  ],
   "files": {
-    "solution": ["square-root.js"],
-    "test": ["square-root.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "square-root.js"
+    ],
+    "test": [
+      "square-root.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "wolf99",
   "source_url": "https://github.com/exercism/problem-specifications/pull/1582"

--- a/exercises/practice/square-root/package.json
+++ b/exercises/practice/square-root/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "smb26",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["strain.js"],
-    "test": ["strain.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "strain.js"
+    ],
+    "test": [
+      "strain.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,27 +1,26 @@
 {
   "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
     "smb26",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["strain.js"],
-    "test": ["strain.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "strain.js"
+    ],
+    "test": [
+      "strain.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -21,15 +19,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "strain.js"
-    ],
-    "test": [
-      "strain.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["strain.js"],
+    "test": ["strain.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -12,15 +10,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "strain.js"
-    ],
-    "test": [
-      "strain.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["strain.js"],
+    "test": ["strain.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/strain/package.json
+++ b/exercises/practice/strain/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,23 +1,24 @@
 {
   "blurb": "Write a function to determine if a list is a sublist of another list.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["sublist.js"],
-    "test": ["sublist.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "sublist.js"
+    ],
+    "test": [
+      "sublist.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Write a function to determine if a list is a sublist of another list.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -11,14 +9,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "sublist.js"
-    ],
-    "test": [
-      "sublist.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["sublist.js"],
+    "test": ["sublist.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,9 +1,31 @@
 {
   "blurb": "Write a function to determine if a list is a sublist of another list.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["sublist.js"],
-    "test": ["sublist.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "sublist.js"
+    ],
+    "test": [
+      "sublist.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Write a function to determine if a list is a sublist of another list.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -18,14 +16,8 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "sublist.js"
-    ],
-    "test": [
-      "sublist.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["sublist.js"],
+    "test": ["sublist.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/sublist/package.json
+++ b/exercises/practice/sublist/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,10 +1,37 @@
 {
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "hayashi-ay",
+    "iagocavalcante",
+    "lantran",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "smb26",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["sum-of-multiples.js"],
-    "test": ["sum-of-multiples.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "sum-of-multiples.js"
+    ],
+    "test": [
+      "sum-of-multiples.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on Problem 1 at Project Euler",
   "source_url": "http://projecteuler.net/problem=1"

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,29 +1,28 @@
 {
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
     "hayashi-ay",
-    "iagocavalcante",
-    "lantran",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
     "smb26",
-    "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["sum-of-multiples.js"],
-    "test": ["sum-of-multiples.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "sum-of-multiples.js"
+    ],
+    "test": [
+      "sum-of-multiples.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on Problem 1 at Project Euler",
   "source_url": "http://projecteuler.net/problem=1"

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -23,15 +21,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "sum-of-multiples.js"
-    ],
-    "test": [
-      "sum-of-multiples.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["sum-of-multiples.js"],
+    "test": ["sum-of-multiples.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on Problem 1 at Project Euler",
   "source_url": "http://projecteuler.net/problem=1"

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "hayashi-ay",
@@ -14,15 +12,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "sum-of-multiples.js"
-    ],
-    "test": [
-      "sum-of-multiples.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["sum-of-multiples.js"],
+    "test": ["sum-of-multiples.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on Problem 1 at Project Euler",
   "source_url": "http://projecteuler.net/problem=1"

--- a/exercises/practice/sum-of-multiples/package.json
+++ b/exercises/practice/sum-of-multiples/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Take input text and output it transposed.",
-  "authors": [
-    "RobinCsl"
-  ],
+  "authors": ["RobinCsl"],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -12,15 +10,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "transpose.js"
-    ],
-    "test": [
-      "transpose.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["transpose.js"],
+    "test": ["transpose.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,25 +1,26 @@
 {
   "blurb": "Take input text and output it transposed.",
-  "authors": ["RobinCsl"],
+  "authors": [
+    "RobinCsl"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["transpose.js"],
-    "test": ["transpose.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "transpose.js"
+    ],
+    "test": [
+      "transpose.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Take input text and output it transposed.",
-  "authors": [
-    "RobinCsl"
-  ],
+  "authors": ["RobinCsl"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -19,15 +17,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "transpose.js"
-    ],
-    "test": [
-      "transpose.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["transpose.js"],
+    "test": ["transpose.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,10 +1,33 @@
 {
   "blurb": "Take input text and output it transposed.",
-  "authors": [],
+  "authors": [
+    "RobinCsl"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["transpose.js"],
-    "test": ["transpose.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "transpose.js"
+    ],
+    "test": [
+      "transpose.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"

--- a/exercises/practice/transpose/package.json
+++ b/exercises/practice/transpose/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,28 +1,28 @@
 {
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "matthewmorgan",
     "msomji",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "WebCu"
   ],
   "files": {
-    "solution": ["triangle.js"],
-    "test": ["triangle.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "triangle.js"
+    ],
+    "test": [
+      "triangle.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Ruby Koans triangle project, parts 1 & 2",
   "source_url": "http://rubykoans.com"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -22,15 +20,9 @@
     "WebCu"
   ],
   "files": {
-    "solution": [
-      "triangle.js"
-    ],
-    "test": [
-      "triangle.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["triangle.js"],
+    "test": ["triangle.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Ruby Koans triangle project, parts 1 & 2",
   "source_url": "http://rubykoans.com"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -14,15 +12,9 @@
     "WebCu"
   ],
   "files": {
-    "solution": [
-      "triangle.js"
-    ],
-    "test": [
-      "triangle.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["triangle.js"],
+    "test": ["triangle.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Ruby Koans triangle project, parts 1 & 2",
   "source_url": "http://rubykoans.com"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "msomji",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "WebCu"
+  ],
   "files": {
-    "solution": ["triangle.js"],
-    "test": ["triangle.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "triangle.js"
+    ],
+    "test": [
+      "triangle.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Ruby Koans triangle project, parts 1 & 2",
   "source_url": "http://rubykoans.com"

--- a/exercises/practice/triangle/package.json
+++ b/exercises/practice/triangle/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "msomji",
@@ -13,15 +11,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "trinary.js"
-    ],
-    "test": [
-      "trinary.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["trinary.js"],
+    "test": ["trinary.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,27 +1,27 @@
 {
   "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
     "msomji",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "SleeplessByte",
     "tejasbubane",
-    "Tyresius92",
     "xarxziux"
   ],
   "files": {
-    "solution": ["trinary.js"],
-    "test": ["trinary.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "trinary.js"
+    ],
+    "test": [
+      "trinary.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -21,15 +19,9 @@
     "xarxziux"
   ],
   "files": {
-    "solution": [
-      "trinary.js"
-    ],
-    "test": [
-      "trinary.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["trinary.js"],
+    "test": ["trinary.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,10 +1,35 @@
 {
   "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "msomji",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["trinary.js"],
-    "test": ["trinary.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "trinary.js"
+    ],
+    "test": [
+      "trinary.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/trinary/package.json
+++ b/exercises/practice/trinary/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,10 +1,34 @@
 {
   "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
-  "authors": [],
+  "authors": [
+    "AakashMallik"
+  ],
+  "contributors": [
+    "ankorGH",
+    "cmccandless",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "matthewmorgan",
+    "paparomeo",
+    "PatrickMcSweeny",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["twelve-days.js"],
-    "test": ["twelve-days.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "twelve-days.js"
+    ],
+    "test": [
+      "twelve-days.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,26 +1,25 @@
 {
   "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
-  "authors": ["AakashMallik"],
+  "authors": [
+    "AakashMallik"
+  ],
   "contributors": [
     "ankorGH",
     "cmccandless",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "matthewmorgan",
-    "paparomeo",
     "PatrickMcSweeny",
-    "PSalant726",
-    "rchavarria",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["twelve-days.js"],
-    "test": ["twelve-days.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "twelve-days.js"
+    ],
+    "test": [
+      "twelve-days.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
-  "authors": [
-    "AakashMallik"
-  ],
+  "authors": ["AakashMallik"],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -20,15 +18,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "twelve-days.js"
-    ],
-    "test": [
-      "twelve-days.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["twelve-days.js"],
+    "test": ["twelve-days.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
-  "authors": [
-    "AakashMallik"
-  ],
+  "authors": ["AakashMallik"],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -11,15 +9,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "twelve-days.js"
-    ],
-    "test": [
-      "twelve-days.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["twelve-days.js"],
+    "test": ["twelve-days.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"

--- a/exercises/practice/twelve-days/package.json
+++ b/exercises/practice/twelve-days/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "G-Rath",
+    "ganderzz",
+    "gargrave",
+    "iagocavalcante",
+    "lantran",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "rpottsoh",
+    "ryanplusplus",
+    "slaymance",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["two-bucket.js"],
-    "test": ["two-bucket.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "two-bucket.js"
+    ],
+    "test": [
+      "two-bucket.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Water Pouring Problem",
   "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/"

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "ganderzz",
@@ -13,15 +11,9 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "two-bucket.js"
-    ],
-    "test": [
-      "two-bucket.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["two-bucket.js"],
+    "test": ["two-bucket.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Water Pouring Problem",
   "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/"

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,28 +1,27 @@
 {
   "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
-    "G-Rath",
     "ganderzz",
-    "gargrave",
-    "iagocavalcante",
-    "lantran",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
-    "rpottsoh",
     "ryanplusplus",
     "slaymance",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["two-bucket.js"],
-    "test": ["two-bucket.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "two-bucket.js"
+    ],
+    "test": [
+      "two-bucket.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Water Pouring Problem",
   "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/"

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -22,15 +20,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "two-bucket.js"
-    ],
-    "test": [
-      "two-bucket.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["two-bucket.js"],
+    "test": ["two-bucket.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Water Pouring Problem",
   "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/"

--- a/exercises/practice/two-bucket/package.json
+++ b/exercises/practice/two-bucket/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,23 +1,11 @@
 {
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
-  "authors": [
-    "laurmurclar"
-  ],
-  "contributors": [
-    "mluisamc",
-    "serixscorpio",
-    "SleeplessByte"
-  ],
+  "authors": ["laurmurclar"],
+  "contributors": ["mluisamc", "serixscorpio", "SleeplessByte"],
   "files": {
-    "solution": [
-      "two-fer.js"
-    ],
-    "test": [
-      "two-fer.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["two-fer.js"],
+    "test": ["two-fer.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,25 +1,23 @@
 {
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
-  "authors": ["laurmurclar"],
+  "authors": [
+    "laurmurclar"
+  ],
   "contributors": [
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
-    "iHiD",
-    "lantran",
-    "matthewmorgan",
     "mluisamc",
-    "paparomeo",
-    "PSalant726",
     "serixscorpio",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["two-fer.js"],
-    "test": ["two-fer.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "two-fer.js"
+    ],
+    "test": [
+      "two-fer.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,10 +1,33 @@
 {
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
-  "authors": [],
+  "authors": [
+    "laurmurclar"
+  ],
+  "contributors": [
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "iHiD",
+    "lantran",
+    "matthewmorgan",
+    "mluisamc",
+    "paparomeo",
+    "PSalant726",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["two-fer.js"],
-    "test": ["two-fer.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "two-fer.js"
+    ],
+    "test": [
+      "two-fer.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
-  "authors": [
-    "laurmurclar"
-  ],
+  "authors": ["laurmurclar"],
   "contributors": [
     "G-Rath",
     "gargrave",
@@ -19,15 +17,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "two-fer.js"
-    ],
-    "test": [
-      "two-fer.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["two-fer.js"],
+    "test": ["two-fer.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }

--- a/exercises/practice/two-fer/package.json
+++ b/exercises/practice/two-fer/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Implement variable length quantity encoding and decoding.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "ankorGH",
     "G-Rath",
@@ -17,15 +15,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "variable-length-quantity.js"
-    ],
-    "test": [
-      "variable-length-quantity.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["variable-length-quantity.js"],
+    "test": ["variable-length-quantity.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A poor Splice developer having to implement MIDI encoding/decoding.",
   "source_url": "https://splice.com"

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -1,23 +1,24 @@
 {
   "blurb": "Implement variable length quantity encoding and decoding.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
-    "G-Rath",
-    "gargrave",
     "hayashi-ay",
-    "iagocavalcante",
-    "paparomeo",
-    "PSalant726",
     "SleeplessByte",
-    "smb26",
-    "tejasbubane",
-    "Tyresius92"
+    "smb26"
   ],
   "files": {
-    "solution": ["variable-length-quantity.js"],
-    "test": ["variable-length-quantity.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "variable-length-quantity.js"
+    ],
+    "test": [
+      "variable-length-quantity.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A poor Splice developer having to implement MIDI encoding/decoding.",
   "source_url": "https://splice.com"

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -1,24 +1,11 @@
 {
   "blurb": "Implement variable length quantity encoding and decoding.",
-  "authors": [
-    "matthewmorgan"
-  ],
-  "contributors": [
-    "ankorGH",
-    "hayashi-ay",
-    "SleeplessByte",
-    "smb26"
-  ],
+  "authors": ["matthewmorgan"],
+  "contributors": ["ankorGH", "hayashi-ay", "SleeplessByte", "smb26"],
   "files": {
-    "solution": [
-      "variable-length-quantity.js"
-    ],
-    "test": [
-      "variable-length-quantity.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["variable-length-quantity.js"],
+    "test": ["variable-length-quantity.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A poor Splice developer having to implement MIDI encoding/decoding.",
   "source_url": "https://splice.com"

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -1,10 +1,31 @@
 {
   "blurb": "Implement variable length quantity encoding and decoding.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "ankorGH",
+    "G-Rath",
+    "gargrave",
+    "hayashi-ay",
+    "iagocavalcante",
+    "paparomeo",
+    "PSalant726",
+    "SleeplessByte",
+    "smb26",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["variable-length-quantity.js"],
-    "test": ["variable-length-quantity.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "variable-length-quantity.js"
+    ],
+    "test": [
+      "variable-length-quantity.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A poor Splice developer having to implement MIDI encoding/decoding.",
   "source_url": "https://splice.com"

--- a/exercises/practice/variable-length-quantity/package.json
+++ b/exercises/practice/variable-length-quantity/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "andreasolund",
     "ankorGH",
@@ -24,15 +22,9 @@
     "ZacharyRSmith"
   ],
   "files": {
-    "solution": [
-      "word-count.js"
-    ],
-    "test": [
-      "word-count.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["word-count.js"],
+    "test": ["word-count.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,10 +1,38 @@
 {
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
-  "authors": [],
+  "authors": [
+    "rchavarria"
+  ],
+  "contributors": [
+    "andreasolund",
+    "ankorGH",
+    "draalger",
+    "G-Rath",
+    "gargrave",
+    "iagocavalcante",
+    "kytrinyx",
+    "lantran",
+    "matthewmorgan",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "ryanplusplus",
+    "SleeplessByte",
+    "tarunvelli",
+    "tejasbubane",
+    "Tyresius92",
+    "ZacharyRSmith"
+  ],
   "files": {
-    "solution": ["word-count.js"],
-    "test": ["word-count.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "word-count.js"
+    ],
+    "test": [
+      "word-count.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,30 +1,30 @@
 {
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
-    "andreasolund",
     "ankorGH",
     "draalger",
-    "G-Rath",
-    "gargrave",
-    "iagocavalcante",
     "kytrinyx",
-    "lantran",
     "matthewmorgan",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "ryanplusplus",
     "SleeplessByte",
     "tarunvelli",
     "tejasbubane",
-    "Tyresius92",
     "ZacharyRSmith"
   ],
   "files": {
-    "solution": ["word-count.js"],
-    "test": ["word-count.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "word-count.js"
+    ],
+    "test": [
+      "word-count.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
-  "authors": [
-    "rchavarria"
-  ],
+  "authors": ["rchavarria"],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -16,15 +14,9 @@
     "ZacharyRSmith"
   ],
   "files": {
-    "solution": [
-      "word-count.js"
-    ],
-    "test": [
-      "word-count.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["word-count.js"],
+    "test": ["word-count.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."
 }

--- a/exercises/practice/word-count/package.json
+++ b/exercises/practice/word-count/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Create a program to solve a word search puzzle.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "hyuko21",
     "ivanvotti",
@@ -11,14 +9,8 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "word-search.js"
-    ],
-    "test": [
-      "word-search.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["word-search.js"],
+    "test": ["word-search.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -1,24 +1,24 @@
 {
   "blurb": "Create a program to solve a word search puzzle.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "G-Rath",
-    "gargrave",
     "hyuko21",
-    "iagocavalcante",
     "ivanvotti",
-    "lantran",
     "msomji",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["word-search.js"],
-    "test": ["word-search.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "word-search.js"
+    ],
+    "test": [
+      "word-search.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -1,9 +1,32 @@
 {
   "blurb": "Create a program to solve a word search puzzle.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "G-Rath",
+    "gargrave",
+    "hyuko21",
+    "iagocavalcante",
+    "ivanvotti",
+    "lantran",
+    "msomji",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["word-search.js"],
-    "test": ["word-search.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "word-search.js"
+    ],
+    "test": [
+      "word-search.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Create a program to solve a word search puzzle.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "G-Rath",
     "gargrave",
@@ -19,14 +17,8 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "word-search.js"
-    ],
-    "test": [
-      "word-search.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["word-search.js"],
+    "test": ["word-search.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/word-search/package.json
+++ b/exercises/practice/word-search/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "hyuko21",
     "msomji",
@@ -13,15 +11,9 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": [
-      "wordy.js"
-    ],
-    "test": [
-      "wordy.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["wordy.js"],
+    "test": ["wordy.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,28 +1,27 @@
 {
   "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
-    "andreasolund",
-    "G-Rath",
-    "gargrave",
     "hyuko21",
-    "iagocavalcante",
-    "lantran",
     "msomji",
     "ovidiu141",
-    "paparomeo",
-    "PSalant726",
     "rchavarria",
     "ryanplusplus",
     "serixscorpio",
-    "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "SleeplessByte"
   ],
   "files": {
-    "solution": ["wordy.js"],
-    "test": ["wordy.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "wordy.js"
+    ],
+    "test": [
+      "wordy.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "andreasolund",
     "G-Rath",
@@ -22,15 +20,9 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "wordy.js"
-    ],
-    "test": [
-      "wordy.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["wordy.js"],
+    "test": ["wordy.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,10 +1,36 @@
 {
   "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "andreasolund",
+    "G-Rath",
+    "gargrave",
+    "hyuko21",
+    "iagocavalcante",
+    "lantran",
+    "msomji",
+    "ovidiu141",
+    "paparomeo",
+    "PSalant726",
+    "rchavarria",
+    "ryanplusplus",
+    "serixscorpio",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["wordy.js"],
-    "test": ["wordy.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "wordy.js"
+    ],
+    "test": [
+      "wordy.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/wordy/package.json
+++ b/exercises/practice/wordy/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -1,21 +1,11 @@
 {
   "blurb": "Score a single throw of dice in the game Yacht",
-  "authors": [
-    "ovidiu141"
-  ],
-  "contributors": [
-    "SleeplessByte"
-  ],
+  "authors": ["ovidiu141"],
+  "contributors": ["SleeplessByte"],
   "files": {
-    "solution": [
-      "yacht.js"
-    ],
-    "test": [
-      "yacht.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["yacht.js"],
+    "test": ["yacht.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "James Kilfiger, using wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Yacht_(dice_game)"

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -1,11 +1,21 @@
 {
   "blurb": "Score a single throw of dice in the game Yacht",
-  "authors": ["ovidiu141"],
-  "contributors": ["paparomeo", "SleeplessByte", "tejasbubane"],
+  "authors": [
+    "ovidiu141"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["yacht.js"],
-    "test": ["yacht.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "yacht.js"
+    ],
+    "test": [
+      "yacht.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "James Kilfiger, using wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Yacht_(dice_game)"

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -1,23 +1,11 @@
 {
   "blurb": "Score a single throw of dice in the game Yacht",
-  "authors": [
-    "ovidiu141"
-  ],
-  "contributors": [
-    "paparomeo",
-    "SleeplessByte",
-    "tejasbubane"
-  ],
+  "authors": ["ovidiu141"],
+  "contributors": ["paparomeo", "SleeplessByte", "tejasbubane"],
   "files": {
-    "solution": [
-      "yacht.js"
-    ],
-    "test": [
-      "yacht.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["yacht.js"],
+    "test": ["yacht.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "James Kilfiger, using wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Yacht_(dice_game)"

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -1,10 +1,23 @@
 {
   "blurb": "Score a single throw of dice in the game Yacht",
-  "authors": [],
+  "authors": [
+    "ovidiu141"
+  ],
+  "contributors": [
+    "paparomeo",
+    "SleeplessByte",
+    "tejasbubane"
+  ],
   "files": {
-    "solution": ["yacht.js"],
-    "test": ["yacht.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "yacht.js"
+    ],
+    "test": [
+      "yacht.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "James Kilfiger, using wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Yacht_(dice_game)"

--- a/exercises/practice/yacht/package.json
+++ b/exercises/practice/yacht/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -1,9 +1,32 @@
 {
   "blurb": "Creating a zipper for a binary tree.",
-  "authors": [],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "felbit",
+    "G-Rath",
+    "ganderzz",
+    "gargrave",
+    "hyuko21",
+    "iagocavalcante",
+    "joshgoebel",
+    "paparomeo",
+    "PSalant726",
+    "rpottsoh",
+    "SleeplessByte",
+    "tejasbubane",
+    "Tyresius92"
+  ],
   "files": {
-    "solution": ["zipper.js"],
-    "test": ["zipper.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "zipper.js"
+    ],
+    "test": [
+      "zipper.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -1,24 +1,25 @@
 {
   "blurb": "Creating a zipper for a binary tree.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "felbit",
-    "G-Rath",
     "ganderzz",
-    "gargrave",
     "hyuko21",
-    "iagocavalcante",
     "joshgoebel",
-    "paparomeo",
-    "PSalant726",
-    "rpottsoh",
     "SleeplessByte",
-    "tejasbubane",
-    "Tyresius92"
+    "tejasbubane"
   ],
   "files": {
-    "solution": ["zipper.js"],
-    "test": ["zipper.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "zipper.js"
+    ],
+    "test": [
+      "zipper.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Creating a zipper for a binary tree.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "felbit",
     "ganderzz",
@@ -12,14 +10,8 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": [
-      "zipper.js"
-    ],
-    "test": [
-      "zipper.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["zipper.js"],
+    "test": ["zipper.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Creating a zipper for a binary tree.",
-  "authors": [
-    "matthewmorgan"
-  ],
+  "authors": ["matthewmorgan"],
   "contributors": [
     "felbit",
     "G-Rath",
@@ -19,14 +17,8 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": [
-      "zipper.js"
-    ],
-    "test": [
-      "zipper.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["zipper.js"],
+    "test": ["zipper.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/zipper/package.json
+++ b/exercises/practice/zipper/package.json
@@ -11,7 +11,7 @@
     "@babel/cli": "^7.13.10",
     "@babel/core": "^7.13.10",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,9 +235,9 @@
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+          "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -264,9 +264,9 @@
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+          "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -303,9 +303,9 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.10.tgz",
-      "integrity": "sha512-YV7r2YxdTUaw84EwNkyrRke/TJHR/UXGiyvACRqvdVJ2/syV2rQuJNnaRLSuYiop8cMRXOgseTGoJCWX0q2fFg==",
+      "version": "7.13.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.11.tgz",
+      "integrity": "sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.12.13",
@@ -365,9 +365,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-          "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
+          "integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==",
           "dev": true
         },
         "@babel/template": {
@@ -382,9 +382,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+          "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -504,9 +504,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-          "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
+          "integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==",
           "dev": true
         },
         "@babel/template": {
@@ -538,9 +538,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+          "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -598,9 +598,9 @@
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+          "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -707,9 +707,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-          "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
+          "integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==",
           "dev": true
         },
         "@babel/template": {
@@ -741,9 +741,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+          "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -1045,9 +1045,9 @@
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+          "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -1254,9 +1254,9 @@
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+          "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -1366,9 +1366,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-          "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
+          "integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==",
           "dev": true
         },
         "@babel/template": {
@@ -1400,9 +1400,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+          "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -1638,6 +1638,25 @@
       "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA==",
       "dev": true
     },
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12.tgz",
+      "integrity": "sha512-d0u3zWKcoZf379fOeJdr1a5WPDny4aOFZ6hlfKivgK0LY7ZxNfoaHL2fWwdGtHyVvra38FC+HVYkO+byfSA8AQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.12"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.13.8",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz",
@@ -1823,9 +1842,9 @@
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.8.tgz",
-      "integrity": "sha512-hpbBwbTgd7Cz1QryvwJZRo1U0k1q8uyBmeXOSQUjdg/A2TASkhR/rz7AyqZ/kS8kbpsNA80rOYbxySBJAqmhhQ==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.12.tgz",
+      "integrity": "sha512-fcEdKOkIB7Tf4IxrgEVeFC4zeJSTr78no9wTdBuZZbqF64kzllU0ybo2zrzm7gUQfxGhBgq4E39oRs8Zx/RMYQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.13.0",
@@ -2184,9 +2203,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-          "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
+          "integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==",
           "dev": true
         },
         "@babel/template": {
@@ -2201,9 +2220,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+          "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -2391,9 +2410,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-          "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
+          "integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==",
           "dev": true
         },
         "@babel/template": {
@@ -2408,9 +2427,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+          "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -2775,15 +2794,16 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.10.tgz",
-      "integrity": "sha512-nOsTScuoRghRtUsRr/c69d042ysfPHcu+KOB4A9aAO9eJYqrkat+LF8G1yp1HD18QiwixT2CisZTr/0b3YZPXQ==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.12.tgz",
+      "integrity": "sha512-JzElc6jk3Ko6zuZgBtjOd01pf9yYDEIH8BcqVuYIuOkzOwDesoa/Nz4gIo4lBG6K861KTV9TvIgmFuT6ytOaAA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.8",
+        "@babel/compat-data": "^7.13.12",
         "@babel/helper-compilation-targets": "^7.13.10",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-option": "^7.12.17",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.13.12",
         "@babel/plugin-proposal-async-generator-functions": "^7.13.8",
         "@babel/plugin-proposal-class-properties": "^7.13.0",
         "@babel/plugin-proposal-dynamic-import": "^7.13.8",
@@ -2794,7 +2814,7 @@
         "@babel/plugin-proposal-numeric-separator": "^7.12.13",
         "@babel/plugin-proposal-object-rest-spread": "^7.13.8",
         "@babel/plugin-proposal-optional-catch-binding": "^7.13.8",
-        "@babel/plugin-proposal-optional-chaining": "^7.13.8",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.12",
         "@babel/plugin-proposal-private-methods": "^7.13.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.12.13",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -2842,7 +2862,7 @@
         "@babel/plugin-transform-unicode-escapes": "^7.12.13",
         "@babel/plugin-transform-unicode-regex": "^7.12.13",
         "@babel/preset-modules": "^0.1.4",
-        "@babel/types": "^7.13.0",
+        "@babel/types": "^7.13.12",
         "babel-plugin-polyfill-corejs2": "^0.1.4",
         "babel-plugin-polyfill-corejs3": "^0.1.3",
         "babel-plugin-polyfill-regenerator": "^0.1.2",
@@ -2850,6 +2870,12 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
+        "@babel/compat-data": {
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.12.tgz",
+          "integrity": "sha512-3eJJ841uKxeV8dcN/2yGEUy+RfgQspPEgQat85umsE1rotuquQ2AbIub4S6j7c50a2d+4myc+zSlnXeIHrOnhQ==",
+          "dev": true
+        },
         "@babel/helper-plugin-utils": {
           "version": "7.13.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
@@ -2875,9 +2901,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+          "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -9511,9 +9537,9 @@
       "dev": true
     },
     "regjsparser": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.7.tgz",
-      "integrity": "sha512-ib77G0uxsA2ovgiYbCVGx4Pv3PSttAx2vIwidqQzbL2U5S4Q+j00HdSAneSBuyVcMvEnTXMjiGgB+DlXozVhpQ==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.8.tgz",
+      "integrity": "sha512-3weFrFQREJhJ2PW+iCGaG6TenyzNSZgsBKZ/oEf6Trme31COSeIWhHw9O6FPkuXktfx+b6Hf/5e6dKPHaROq2g==",
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@babel/core": "^7.13.10",
     "@babel/node": "^7.13.12",
     "@babel/plugin-syntax-bigint": "^7.8.3",
-    "@babel/preset-env": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
With v3, we've introduced the idea of exercise authors and contributors. This information is stored in the exercise's `.meta/config.json` file (see [the docs](https://github.com/exercism/docs/blob/main/anatomy/tracks/practice-exercises.md#file-metaconfigjson)).

Concept Exercises, which are all new, have all defined their authors and contributors. Practice Exercises though are missing this information. In this PR, we attempt to populate the authors and contributors of Practice Exercises based on their commit history.

## Algorithm

We start out by looking at the current Practice Exercises. For each Practice Exercise, we'll look at the commit history of its files to see which commits did something with that Practice Exercise. How renames are handled is discussed in the "Renames" section later in this document. 

Each commit that we can link to a Practice Exercise will be used to determine authorship/contributorship. Here is how we assign authorship/contributorship:

### Authors

1. Find the Git commit author of the oldest commit linked to that Practice Exercise. As there can only be one oldest commit, we only have one author
2. Find the GitHub username for the Git commit author of that commit
3. Add the GitHub username of the Git commit author to the `authors` key in the `.meta/config.json` file

### Contributors

1. Find the Git commit authors of all but the oldest commit linked to that Practice Exercise. If there is only one commit, there won't be any contributors.
1. Exclude the Git commit author of the oldest commit from the list of Git commit authors (an author is _not_ also a contributor) 
2. Find the GitHub usernames for the Git commit authors of those commits
3. Add the GitHub usernames of the Git commit authors to the `contributor` key in the `.meta/config.json` file

We're using the GitHub GraphQL API to find the username of a commit author. In some cases though, a username cannot be found for a commit (e.g. due to the user account no longer existing), in which case we'll skip the commit. 

## Renames

There is a select number of Practice Exercises that might have been renamed at some point. You can ask Git to "follow" a file over its renames using `git log --follow <file>`, which will also return commits made before renames. Unfortunately, Git does not store renames, it just stores the contents of the renamed files and tries to guess if a file was renamed by looking at its contents. This _can_ (and will) lead to false positives, where Git will think a file has been renamed whereas it hasn't. As we don't want to have incorrect authors/contributors for exercises, we're ignoring renames. The only exception to this are known exercise renames:

- `bracket-push` was renamed to `matching-brackets`
- `retree` was renamed to `satellite`
- `resistor-colors` was renamed to `resistor-color-duo`
- `kindergarden-garden` was renamed to `kindergarten-garden`

If you know of a rename of a Practice Exercise, please check to see if its authors and contributors are correctly set.

## Exclusions

There are some commits that we skip over, which thus don't influence the authors/contributors list:

- Commits authored by `dependabot[bot]`, `dependabot-preview[bot]` or `github-actions[bot]`
- Bulk update PRs made by `ErikSchierboom` or `kytrinx` to update the track

## Maintainer TODO list

These are the things you, the maintainers, should do:

- Check the authors and contributors, adding/removing users where the data is missing or incorrect
- Double-check any renamed Practice Exercises
- Check for Practice Exercises with missing authors, which is most likely due to the author not being on GitHub anymore 
- Add additional authors if you know that a Practice Exercise has actually been created by more than one author 

If you find something needs updating, just push a new commit to this PR.

## Tracking

https://github.com/exercism/v3-launch/issues/24